### PR TITLE
Error message and transaction completion header styling update and css refactoring

### DIFF
--- a/app/views/helpers/templates/inlineDateInput.scala.html
+++ b/app/views/helpers/templates/inlineDateInput.scala.html
@@ -6,7 +6,7 @@
 @import play.api.i18n._
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
-@fieldsetClasses = @{if(formItem.hasErrors && (formItem.errors.find(_.key != "psoAmt").isDefined)) "form-field--error" else "" }
+@fieldsetClasses = @{if(formItem.hasErrors && (formItem.errors.find(_.key != "psoAmt").isDefined)) "form-group-error" else "" }
 
 <fieldset class="form-group form-date @fieldsetClasses" id="@fieldName-fieldset">
 

--- a/app/views/helpers/templates/inputRadioGroupHidden.scala.html
+++ b/app/views/helpers/templates/inputRadioGroupHidden.scala.html
@@ -7,7 +7,7 @@
 @import views.html.helper._
 
 @elements = @{new FieldElements(field.id, field, null, args.toMap, lang) }
-@fieldsetClass = {@elements.args.get('_groupClass)@if(elements.hasErrors){ form-field--error}}
+@fieldsetClass = {@elements.args.get('_groupClass)@if(elements.hasErrors){ form-group-error}}
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
 @idHidden = @{ elements.args.get('_idHidden).getOrElse("")}
 @classHidden = @{ elements.args.get('_classHidden).getOrElse("") }

--- a/app/views/helpers/templates/oneOfManyErrorWrapper.scala.html
+++ b/app/views/helpers/templates/oneOfManyErrorWrapper.scala.html
@@ -2,7 +2,7 @@
 
 @errs = @{form.errors.filter(_.key.contains("noFieldsCompleted"))}
 
-<div class="@if(errs.nonEmpty) {form-field--error} @if(form.globalErrors.nonEmpty) {form-field--error}">
+<div class="@if(errs.nonEmpty) {form-group-error} @if(form.globalErrors.nonEmpty) {form-group-error}">
     @errs.map { err =>
         <span class="error-notification" id="@{err.key}" role="tooltip">
             @messages(err.message)

--- a/app/views/helpers/templates/payInput.scala.html
+++ b/app/views/helpers/templates/payInput.scala.html
@@ -1,0 +1,95 @@
+@*
+* Copyright 2015 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
+@(field: play.api.data.Field, args: (Symbol,Any)*)(implicit messages: Messages)
+
+@import play.api.i18n._
+@import views.html.helper._
+
+
+@elements = @{ new FieldElements(field.id, field, null, args.toMap, messages) }
+@parentField = @{args.toMap.get('parentField).asInstanceOf[Option[Field]]}
+@parentElements = @{parentField.map(pf => new FieldElements(pf.id, pf, null, Map(), messages) )}
+@value = @{ field.value match { case Some(x) => x case None => "" case x => x }}
+@labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
+@labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
+
+
+<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-group-error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
+
+    @if(!elements.args.contains('_hideErrors)) {
+        @elements.errors.map { error =>
+              <span class="error-notification"
+                  @if(elements.args.contains('_error_id)) {
+                        id="@elements.args.get('_error_id)"
+                  }
+                  role="tooltip"
+                  data-journey="search-page:error:@elements.field.name">
+                  @Messages(error)
+              </span>
+        }
+    }
+
+
+    @if(parentElements.isDefined) {
+        @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}
+    }
+
+    @if(!labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint"
+                @if(elements.args.contains('_hintId)) {
+                    id="@elements.args.get('_hintId)"
+                }>
+                @elements.args.get('_inputHint)
+            </span>
+        }
+        @if(labelHighlight){</strong>}
+
+    }
+    <input
+        @if( elements.args.contains('_type)){type="@elements.args.get('_type)" }else{type="text" }
+        @if( elements.args.contains('_dataAttributes) ){ @elements.args.get('_dataAttributes)}
+        @if( elements.args.get('_inputClass) ){ class="@elements.args.get('_inputClass)" }
+        @if( elements.args.get('_autoComplete) ){ autocomplete="@elements.args.get('_autoComplete)" }
+           name="@elements.field.name"
+           id="@elements.field.name"
+           value="@value"
+        @if(elements.args.get('_error_id).isDefined) { aria-labeledby="@elements.args.get('_error_id)" }
+        @if(elements.args.get('_hintId).isDefined) { aria-describedby="@elements.args.get('_hintId)" }
+        @if(elements.args.get('_maxlength).isDefined) { maxlength="@elements.args.get('_maxlength)" }
+        @if(elements.args.get('_min).isDefined) { min="@elements.args.get('_min)" }
+        @if(elements.args.get('_max).isDefined) { max="@elements.args.get('_max)" }
+        @if(elements.args.get('_pattern).isDefined) { pattern="@elements.args.get('_pattern)" }
+        @if(elements.args.get('_title).isDefined) { title="@elements.args.get('_title)" }
+        @if(elements.args.get('_required).isDefined) { required }
+           />
+
+    @if(labelAfter && elements.args.contains('_label)) {
+        @if(labelHighlight){<strong>}
+        <span @if(elements.args.contains('_labelTextClass)) { class="@elements.args.get('_labelTextClass)"}>
+            @elements.label
+        </span>
+        @if(elements.args.contains('_inputHint) ){
+            <span class="form-hint">@elements.args.get('_inputHint)</span>
+        }
+        @if(labelHighlight){</strong>}
+    }
+
+</label>

--- a/app/views/helpers/templates/payeErrorSummary.scala.html
+++ b/app/views/helpers/templates/payeErrorSummary.scala.html
@@ -1,12 +1,12 @@
 @(heading: String, form: Form[_], classes: Seq[String] = Seq.empty, dataJourney: Option[String] = None)(implicit messages: Messages)
 
-<div class="flash error-summary@if(form.hasErrors) { error-summary--show} @classes.mkString(" ")"
+<div class="error-summary@if(form.hasErrors) { error-summary--show} @classes.mkString(" ")"
     id="error-summary-display"
     role="alert"
     aria-labelledby="error-summary-heading"
     tabindex="-1">
     <h2 id="error-summary-heading" class="h3-heading">@heading</h2>
-    <ul class="js-error-summary-messages">
+    <ul class="error-summary-list">
         @if(form.hasErrors) {
         @form.errors.distinct.map { error =>
         <li role="tooltip" @dataJourney.map(page => Html(s"""data-journey="${page}:error:${error.key}""""))>

--- a/app/views/helpers/templates/payeInput.scala.html
+++ b/app/views/helpers/templates/payeInput.scala.html
@@ -1,5 +1,5 @@
 @*
-* Copyright 2015 HM Revenue & Customs
+* Copyright 2017 HM Revenue & Customs
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/app/views/helpers/templates/payeInputRadioGroup.scala.html
+++ b/app/views/helpers/templates/payeInputRadioGroup.scala.html
@@ -3,7 +3,7 @@
 @import views.html.helper._
 
 @elements = @{new FieldElements(field.id, field, null, args.toMap, messages) }
-@fieldsetClass = {@elements.args.get('_groupClass)@if(elements.hasErrors){ form-field--error}}
+@fieldsetClass = {@elements.args.get('_groupClass)@if(elements.hasErrors){ form-group-error}}
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
 
 <fieldset class="@fieldsetClass" id="@field.id"
@@ -14,7 +14,7 @@
         </legend>
     }
     @if(elements.args.get('_helpText).isDefined) {
-        <span class="form-hint">
+        <span class="error-message">
             @elements.args.get('_helpText)
         </span>
     }

--- a/app/views/helpers/templates/payeTextArea.scala.html
+++ b/app/views/helpers/templates/payeTextArea.scala.html
@@ -25,7 +25,7 @@
 
 @labelAfter = @{ elements.args.get('_labelAfter).getOrElse(false).asInstanceOf[Boolean] }
 
-<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}" @if( elements.args.get('_dataCharCounter) ){ data-char-counter="@elements.args.get('_dataCharCounter)" }>
+<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-group-error}" @if( elements.args.get('_dataCharCounter) ){ data-char-counter="@elements.args.get('_dataCharCounter)" }>
     @elements.errors.map { error => <span class="error-notification">@Messages(error)</span>}
     @if(parentElements.isDefined) {
         @parentElements.get.errors.map { error => <span class="error-notification">@Messages(error)</span>}

--- a/app/views/pages/companyDetails/businessContactDetails.scala.html
+++ b/app/views/pages/companyDetails/businessContactDetails.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary}
+@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payInput}
 @import models.DigitalContactDetails
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @(contactForm: Form[DigitalContactDetails])(implicit request: Request[_], messages: Messages)
@@ -9,7 +9,7 @@
             @Messages("pages.businessContact.heading")
         </legend>
         <div class="form-group">
-            @govHelpers.input(
+            @payInput(
             contactForm("businessEmail"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
@@ -18,7 +18,7 @@
         </div>
 
         <div class="form-group">
-            @govHelpers.input(
+            @payInput(
             contactForm("mobileNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",
@@ -27,7 +27,7 @@
         </div>
 
         <div>
-            @govHelpers.input(
+            @payInput(
             contactForm("phoneNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",

--- a/app/views/pages/companyDetails/businessContactDetails.scala.html
+++ b/app/views/pages/companyDetails/businessContactDetails.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payInput}
+@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payeInput}
 @import models.DigitalContactDetails
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @(contactForm: Form[DigitalContactDetails])(implicit request: Request[_], messages: Messages)
@@ -9,7 +9,7 @@
             @Messages("pages.businessContact.heading")
         </legend>
         <div class="form-group">
-            @payInput(
+            @payeInput(
             contactForm("businessEmail"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
@@ -18,7 +18,7 @@
         </div>
 
         <div class="form-group">
-            @payInput(
+            @payeInput(
             contactForm("mobileNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",
@@ -27,7 +27,7 @@
         </div>
 
         <div>
-            @payInput(
+            @payeInput(
             contactForm("phoneNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",

--- a/app/views/pages/companyDetails/ppobAddress.scala.html
+++ b/app/views/pages/companyDetails/ppobAddress.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{addressDisplay, payeInputRadioGroup}
+@import helpers.templates.{addressDisplay, payeInputRadioGroup, payeErrorSummary}
 @import models.Address
 @import models.view.{ChosenAddress, PrepopAddress}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
@@ -6,7 +6,7 @@
 @(chooseAddressForm: Form[ChosenAddress], roAddress: Option[Address], ppobAddress: Option[Address], prepopAddresses: Map[Int, Address])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = messages("pages.ppobAddress.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         messages("app.common.errorSummaryLabel"),
         chooseAddressForm
     )

--- a/app/views/pages/companyDetails/tradingName.scala.html
+++ b/app/views/pages/companyDetails/tradingName.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{formHiddenYesNoRadio, hiddenDetails}
+@import helpers.templates.{formHiddenYesNoRadio, hiddenDetails, payeErrorSummary}
 @import models.view.TradingName
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -25,7 +25,7 @@
 
 @main_template(title = Messages("pages.tradingName.title")) {
 
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), tradingNameForm
     )
 

--- a/app/views/pages/companyDetails/tradingName.scala.html
+++ b/app/views/pages/companyDetails/tradingName.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.{formHiddenYesNoRadio, hiddenDetails, payeErrorSummary, payInput}
+@import helpers.templates.{formHiddenYesNoRadio, hiddenDetails, payeErrorSummary, payeInput}
 @import models.view.TradingName
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(tradingNameForm: Form[TradingName], companyName: String)(implicit request: Request[_], messages: Messages)
 
 @hiddenYesNoContent = {
-    @payInput(
+    @payeInput(
         tradingNameForm("tradingName"),
         '_labelClass -> "form-label cascading",
         '_label -> Messages("pages.tradingName.tradingNameLabel")

--- a/app/views/pages/companyDetails/tradingName.scala.html
+++ b/app/views/pages/companyDetails/tradingName.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.{formHiddenYesNoRadio, hiddenDetails, payeErrorSummary}
+@import helpers.templates.{formHiddenYesNoRadio, hiddenDetails, payeErrorSummary, payInput}
 @import models.view.TradingName
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(tradingNameForm: Form[TradingName], companyName: String)(implicit request: Request[_], messages: Messages)
 
 @hiddenYesNoContent = {
-    @govHelpers.input(
+    @payInput(
         tradingNameForm("tradingName"),
         '_labelClass -> "form-label cascading",
         '_label -> Messages("pages.tradingName.tradingNameLabel")
@@ -40,10 +40,10 @@
 
     <div class="inline form-group">
         @formHiddenYesNoRadio(
-        tradingNameForm,
-        "differentName",
-        Messages("pages.tradingName.legend"),
-        hiddenYesNoContent
+            tradingNameForm,
+            "differentName",
+            Messages("pages.tradingName.legend"),
+            hiddenYesNoContent
         )
 
     </div>

--- a/app/views/pages/completionCapacity.scala.html
+++ b/app/views/pages/completionCapacity.scala.html
@@ -1,6 +1,6 @@
 @import models.view.CompletionCapacity
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import views.html.helpers.templates.inputRadioGroupHidden
+@import views.html.helpers.templates.{inputRadioGroupHidden, payeErrorSummary}
 
 @(completionCapacityForm: Form[CompletionCapacity])(implicit request: Request[_], messages: Messages)
 
@@ -15,7 +15,7 @@
 
 @main_template(title = messages("pages.completionCapacity.title")) {
 
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), completionCapacityForm
     )
 

--- a/app/views/pages/completionCapacity.scala.html
+++ b/app/views/pages/completionCapacity.scala.html
@@ -1,11 +1,11 @@
 @import models.view.CompletionCapacity
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import views.html.helpers.templates.{inputRadioGroupHidden, payeErrorSummary, payInput}
+@import views.html.helpers.templates.{inputRadioGroupHidden, payeErrorSummary, payeInput}
 
 @(completionCapacityForm: Form[CompletionCapacity])(implicit request: Request[_], messages: Messages)
 
 @otherHidden = {
-    @payInput(
+    @payeInput(
         completionCapacityForm("completionCapacityOther"),
         '_inputClass -> "form-control-1-2",
         '_labelClass -> "form-label cascading",

--- a/app/views/pages/completionCapacity.scala.html
+++ b/app/views/pages/completionCapacity.scala.html
@@ -1,11 +1,11 @@
 @import models.view.CompletionCapacity
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import views.html.helpers.templates.{inputRadioGroupHidden, payeErrorSummary}
+@import views.html.helpers.templates.{inputRadioGroupHidden, payeErrorSummary, payInput}
 
 @(completionCapacityForm: Form[CompletionCapacity])(implicit request: Request[_], messages: Messages)
 
 @otherHidden = {
-    @govHelpers.input(
+    @payInput(
         completionCapacityForm("completionCapacityOther"),
         '_inputClass -> "form-control-1-2",
         '_labelClass -> "form-label cascading",

--- a/app/views/pages/directorDetails.scala.html
+++ b/app/views/pages/directorDetails.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{hiddenDetails, oneOfManyErrorWrapper, payeErrorSummary, payInput}
+@import helpers.templates.{hiddenDetails, oneOfManyErrorWrapper, payeErrorSummary, payeInput}
 @import models.view.Ninos
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -10,7 +10,7 @@
 
         @helper.repeat(ninoForm("nino")) { ninoField =>
             <div class="form-field">
-                @payInput(
+                @payeInput(
                     ninoField,
                     '_inputClass -> "form-control-1-2 form-control--block",
                     '_labelClass -> "form-label",

--- a/app/views/pages/directorDetails.scala.html
+++ b/app/views/pages/directorDetails.scala.html
@@ -41,8 +41,9 @@
     </div>
 
     @govHelpers.form(action = controllers.userJourney.routes.DirectorDetailsController.submitDirectorDetails()) {
-
-        @oneOfManyErrorWrapper(ninoForm, formContent)
+        <div class="form-group">
+            @oneOfManyErrorWrapper(ninoForm, formContent)
+        </div>
 
         <div class="form-group">
             <button class="button" type="submit" id="continue" >@messages("app.common.saveAndContinue")</button>

--- a/app/views/pages/directorDetails.scala.html
+++ b/app/views/pages/directorDetails.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{hiddenDetails, oneOfManyErrorWrapper, payeErrorSummary}
+@import helpers.templates.{hiddenDetails, oneOfManyErrorWrapper, payeErrorSummary, payInput}
 @import models.view.Ninos
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -10,7 +10,7 @@
 
         @helper.repeat(ninoForm("nino")) { ninoField =>
             <div class="form-field">
-                @govHelpers.input(
+                @payInput(
                     ninoField,
                     '_inputClass -> "form-control-1-2 form-control--block",
                     '_labelClass -> "form-label",

--- a/app/views/pages/eligibility/companyEligibility.scala.html
+++ b/app/views/pages/eligibility/companyEligibility.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.payeInputRadioGroup
+@import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.CompanyEligibility
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(companyEligibilityForm: Form[CompanyEligibility])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("pages.companyEligibility.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), companyEligibilityForm
     )
     <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.companyEligibility.heading")</h1>

--- a/app/views/pages/eligibility/directorEligibility.scala.html
+++ b/app/views/pages/eligibility/directorEligibility.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.payeInputRadioGroup
+@import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.DirectorEligibility
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(directorEligibilityForm: Form[DirectorEligibility])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("pages.directorEligibility.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), directorEligibilityForm
     )
     <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.directorEligibility.heading")</h1>

--- a/app/views/pages/employmentDetails/companyPension.scala.html
+++ b/app/views/pages/employmentDetails/companyPension.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.payeInputRadioGroup
+@import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.CompanyPension
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(companyPensionForm: Form[CompanyPension])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("pages.companyPension.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), companyPensionForm
     )
 

--- a/app/views/pages/employmentDetails/employingStaff.scala.html
+++ b/app/views/pages/employmentDetails/employingStaff.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.payeInputRadioGroup
+@import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.EmployingStaff
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(employingStaffForm: Form[EmployingStaff])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("pages.employingStaff.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), employingStaffForm
     )
     <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.employingStaff.heading")</h1>

--- a/app/views/pages/employmentDetails/firstPayment.scala.html
+++ b/app/views/pages/employmentDetails/firstPayment.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{hiddenDetails, inlineDateInput}
+@import helpers.templates.{hiddenDetails, inlineDateInput, payeErrorSummary}
 @import models.view.FirstPayment
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -16,7 +16,7 @@
 }
 
 @main_template(title = Messages("pages.firstPayment.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"),
         firstPaymentForm
     )

--- a/app/views/pages/employmentDetails/subcontractors.scala.html
+++ b/app/views/pages/employmentDetails/subcontractors.scala.html
@@ -1,12 +1,12 @@
-@import helpers.templates.payeInputRadioGroup
+@import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.Subcontractors
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(subcontractorsForm: Form[Subcontractors])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("pages.subcontractors.title")) {
-    @govHelpers.errorSummary(
-    Messages("app.common.errorSummaryLabel"), subcontractorsForm
+    @payeErrorSummary(
+        Messages("app.common.errorSummaryLabel"), subcontractorsForm
     )
     <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.subcontractors.heading")</h1>
     @govHelpers.form(action = controllers.userJourney.routes.EmploymentController.submitSubcontractors) {

--- a/app/views/pages/error/submissionFailed.scala.html
+++ b/app/views/pages/error/submissionFailed.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.payeErrorSummary
+@import helpers.templates.{payeErrorSummary, payInput, payeTextArea}
 @import models.view.Ticket
 @(deskproForm: Form[Ticket])(implicit request: Request[_], messages: Messages)
 
@@ -25,7 +25,7 @@
     <fieldset class="form-group">
       <legend class="visuallyhidden">@Messages("errorPages.failedSubmission.detail")</legend>
         <div class="form-field">
-          @govHelpers.input(
+          @payInput(
             deskproForm("name"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
@@ -33,14 +33,14 @@
           )
         </div>
         <div class="form-field">
-          @govHelpers.input(
+          @payInput(
             deskproForm("email"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
             '_label -> messages("errorPages.failedSubmission.q2")
           )
         </div>
-          @govHelpers.textArea(
+          @payeTextArea(
             deskproForm("message"),
             '_inputClass -> "input--medium input--cleared",
             '_label -> messages("errorPages.failedSubmission.q3")

--- a/app/views/pages/error/submissionFailed.scala.html
+++ b/app/views/pages/error/submissionFailed.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{payeErrorSummary, payInput, payeTextArea}
+@import helpers.templates.{payeErrorSummary, payeInput, payeTextArea}
 @import models.view.Ticket
 @(deskproForm: Form[Ticket])(implicit request: Request[_], messages: Messages)
 
@@ -25,7 +25,7 @@
     <fieldset class="form-group">
       <legend class="visuallyhidden">@Messages("errorPages.failedSubmission.detail")</legend>
         <div class="form-field">
-          @payInput(
+          @payeInput(
             deskproForm("name"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
@@ -33,7 +33,7 @@
           )
         </div>
         <div class="form-field">
-          @payInput(
+          @payeInput(
             deskproForm("email"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",

--- a/app/views/pages/natureOfBusiness.scala.html
+++ b/app/views/pages/natureOfBusiness.scala.html
@@ -1,12 +1,12 @@
 @import models.view.NatureOfBusiness
-@import helpers.templates.payeTextArea
+@import helpers.templates.{payeTextArea, payeErrorSummary}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(sicForm: Form[NatureOfBusiness])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = messages("pages.natureOfBusiness.title")) {
 
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), sicForm
     )
 

--- a/app/views/pages/payeContact/correspondenceAddress.scala.html
+++ b/app/views/pages/payeContact/correspondenceAddress.scala.html
@@ -1,12 +1,12 @@
 @import models.Address
 @import models.view.{ChosenAddress, PrepopAddress}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import views.html.helpers.templates.{payeInputRadioGroup, addressDisplay}
+@import views.html.helpers.templates.{payeInputRadioGroup, addressDisplay, payeErrorSummary}
 
 @(chooseAddressForm: Form[ChosenAddress], roAddress: Option[Address], ppobAddress: Option[Address], correspondenceAddress: Option[Address], prepopAddresses: Map[Int, Address])(implicit request: Request[_], messages: Messages)
 
 @main_template(title = messages("pages.correspondenceAddress.title")) {
-    @govHelpers.errorSummary(
+    @payeErrorSummary(
         messages("app.common.errorSummaryLabel"),
         chooseAddressForm
     )

--- a/app/views/pages/payeContact/payeContactDetails.scala.html
+++ b/app/views/pages/payeContact/payeContactDetails.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary}
+@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payInput}
 @import models.view.PAYEContactDetails
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @(contactForm: Form[PAYEContactDetails])(implicit request: Request[_], messages: Messages)
@@ -53,7 +53,7 @@
                     @Html(messages("pages.payeContact.p1"))
                 </legend>
                 <div class="form-group">
-                    @govHelpers.input(
+                    @payInput(
                     contactForm("name"),
                     '_inputClass -> "form-control-1-2",
                     '_labelClass -> "form-label cascading",

--- a/app/views/pages/payeContact/payeContactDetails.scala.html
+++ b/app/views/pages/payeContact/payeContactDetails.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payInput}
+@import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payeInput}
 @import models.view.PAYEContactDetails
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @(contactForm: Form[PAYEContactDetails])(implicit request: Request[_], messages: Messages)
@@ -9,7 +9,7 @@
             @Messages("pages.payeContact.heading")
         </legend>
         <div class="form-group">
-            @payInput(
+            @payeInput(
             contactForm("digitalContact.contactEmail"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
@@ -18,7 +18,7 @@
         </div>
 
         <div class="form-group">
-            @payInput(
+            @payeInput(
             contactForm("digitalContact.mobileNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",
@@ -27,7 +27,7 @@
         </div>
 
         <div>
-            @payInput(
+            @payeInput(
             contactForm("digitalContact.phoneNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",
@@ -53,7 +53,7 @@
                     @Html(messages("pages.payeContact.p1"))
                 </legend>
                 <div class="form-group">
-                    @payInput(
+                    @payeInput(
                     contactForm("name"),
                     '_inputClass -> "form-control-1-2",
                     '_labelClass -> "form-label cascading",

--- a/app/views/pages/payeContact/payeContactDetails.scala.html
+++ b/app/views/pages/payeContact/payeContactDetails.scala.html
@@ -9,7 +9,7 @@
             @Messages("pages.payeContact.heading")
         </legend>
         <div class="form-group">
-            @govHelpers.input(
+            @payInput(
             contactForm("digitalContact.contactEmail"),
             '_inputClass -> "form-control-1-2",
             '_labelClass -> "form-label cascading",
@@ -18,7 +18,7 @@
         </div>
 
         <div class="form-group">
-            @govHelpers.input(
+            @payInput(
             contactForm("digitalContact.mobileNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",
@@ -27,7 +27,7 @@
         </div>
 
         <div>
-            @govHelpers.input(
+            @payInput(
             contactForm("digitalContact.phoneNumber"),
             '_labelClass -> "form-label cascading",
             '_inputClass -> "form-control-1-2",

--- a/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{payeErrorSummary, payInput}
+@import helpers.templates.{payeErrorSummary, payeInput}
 @import models.test.CoHoCompanyDetailsFormModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -15,67 +15,67 @@
 @govHelpers.form(action = controllers.test.routes.TestCoHoController.submitCoHoCompanyDetailsSetup) {
 
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
             cohoForm("companyName"),
             '_label -> "Company name"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("sicCodes[0]"),
         '_label -> "SIC code 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("descriptions[0]"),
         '_label -> "Description 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("sicCodes[1]"),
         '_label -> "SIC code 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("descriptions[1]"),
         '_label -> "Description 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("sicCodes[2]"),
         '_label -> "SIC code 3"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("descriptions[2]"),
         '_label -> "Description 3"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("sicCodes[3]"),
         '_label -> "SIC code 4"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("descriptions[3]"),
         '_label -> "Description 4"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("sicCodes[4]"),
         '_label -> "SIC code 5"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         cohoForm("descriptions[4]"),
         '_label -> "Description 5"
         )

--- a/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
@@ -1,3 +1,4 @@
+@import helpers.templates.payeErrorSummary
 @import models.test.CoHoCompanyDetailsFormModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -5,7 +6,7 @@
 
 
 
-@govHelpers.errorSummary(
+@gpayeErrorSummary(
     Messages("app.common.errorSummaryLabel"), cohoForm
 )
 

--- a/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.payeErrorSummary
+@import helpers.templates.{payeErrorSummary, payInput}
 @import models.test.CoHoCompanyDetailsFormModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -15,67 +15,67 @@
 @govHelpers.form(action = controllers.test.routes.TestCoHoController.submitCoHoCompanyDetailsSetup) {
 
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
             cohoForm("companyName"),
             '_label -> "Company name"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("sicCodes[0]"),
         '_label -> "SIC code 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("descriptions[0]"),
         '_label -> "Description 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("sicCodes[1]"),
         '_label -> "SIC code 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("descriptions[1]"),
         '_label -> "Description 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("sicCodes[2]"),
         '_label -> "SIC code 3"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("descriptions[2]"),
         '_label -> "Description 3"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("sicCodes[3]"),
         '_label -> "SIC code 4"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("descriptions[3]"),
         '_label -> "Description 4"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("sicCodes[4]"),
         '_label -> "SIC code 5"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         cohoForm("descriptions[4]"),
         '_label -> "Description 5"
         )

--- a/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
@@ -6,7 +6,7 @@
 
 
 
-@gpayeErrorSummary(
+@payeErrorSummary(
     Messages("app.common.errorSummaryLabel"), cohoForm
 )
 

--- a/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{payeErrorSummary, payInput}
+@import helpers.templates.{payeErrorSummary, payeInput}
 @import models.api.{CompanyDetails => CompanyDetailsAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -14,13 +14,13 @@
 @govHelpers.form(action = controllers.test.routes.TestRegSetupController.submitRegSetupCompanyDetails) {
 
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("companyName"),
         '_label -> "Company name"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("tradingName"),
         '_label -> "Trading name (optional)"
         )
@@ -28,43 +28,43 @@
 
     <h2>RO Address</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.line1"),
         '_label -> "RO Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.line2"),
         '_label -> "RO Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.line3"),
         '_label -> "RO Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.line4"),
         '_label -> "RO Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.postCode"),
         '_label -> "RO Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.country"),
         '_label -> "RO Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("roAddress.auditRef"),
         '_label -> "RO Address Audit Ref (optional)"
         )
@@ -72,62 +72,62 @@
 
     <h2>PPOB Address</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.line1"),
         '_label -> "PPOB Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.line2"),
         '_label -> "PPOB Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.line3"),
         '_label -> "PPOB Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.line4"),
         '_label -> "PPOB Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.postCode"),
         '_label -> "PPOB Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.country"),
         '_label -> "PPOB Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("ppobAddress.auditRef"),
         '_label -> "PPOB Address Audit Ref (optional)"
         )
     </div>
 
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("businessContactDetails.businessEmail"),
         '_label -> "Business email (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("businessContactDetails.mobileNumber"),
         '_label -> "Mobile number (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         detailsForm("businessContactDetails.phoneNumber"),
         '_label -> "Business telephone (optional)"
         )

--- a/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.payeErrorSummary
+@import helpers.templates.{payeErrorSummary, payInput}
 @import models.api.{CompanyDetails => CompanyDetailsAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
@@ -14,13 +14,13 @@
 @govHelpers.form(action = controllers.test.routes.TestRegSetupController.submitRegSetupCompanyDetails) {
 
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("companyName"),
         '_label -> "Company name"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("tradingName"),
         '_label -> "Trading name (optional)"
         )
@@ -28,43 +28,43 @@
 
     <h2>RO Address</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.line1"),
         '_label -> "RO Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.line2"),
         '_label -> "RO Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.line3"),
         '_label -> "RO Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.line4"),
         '_label -> "RO Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.postCode"),
         '_label -> "RO Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.country"),
         '_label -> "RO Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("roAddress.auditRef"),
         '_label -> "RO Address Audit Ref (optional)"
         )
@@ -72,62 +72,62 @@
 
     <h2>PPOB Address</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.line1"),
         '_label -> "PPOB Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.line2"),
         '_label -> "PPOB Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.line3"),
         '_label -> "PPOB Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.line4"),
         '_label -> "PPOB Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.postCode"),
         '_label -> "PPOB Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.country"),
         '_label -> "PPOB Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("ppobAddress.auditRef"),
         '_label -> "PPOB Address Audit Ref (optional)"
         )
     </div>
 
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("businessContactDetails.businessEmail"),
         '_label -> "Business email (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("businessContactDetails.mobileNumber"),
         '_label -> "Mobile number (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         detailsForm("businessContactDetails.phoneNumber"),
         '_label -> "Business telephone (optional)"
         )

--- a/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
@@ -1,10 +1,11 @@
+@import helpers.templates.payeErrorSummary
 @import models.api.{CompanyDetails => CompanyDetailsAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(detailsForm: Form[CompanyDetailsAPI])(implicit request: Request[_], messages: Messages)
 
 
-@govHelpers.errorSummary(
+@payeErrorSummary(
     Messages("app.common.errorSummaryLabel"), detailsForm
 )
 

--- a/app/views/pages/test/payeRegPAYEContactSetup.scala.html
+++ b/app/views/pages/test/payeRegPAYEContactSetup.scala.html
@@ -1,6 +1,6 @@
 @import models.api.{PAYEContact => PAYEContactAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import helpers.templates.{inlineDateInput, payeErrorSummary}
+@import helpers.templates.{inlineDateInput, payeErrorSummary, payInput}
 @import pages.test.testHelpers.manualPrePopulatedInput
 
 @(payeForm: Form[PAYEContactAPI])(implicit request: Request[_], messages: Messages)
@@ -15,25 +15,25 @@
 
     <h2>Name and tel etc.</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContactDetails.name"),
         '_label -> "Contact name"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContactDetails.digitalContactDetails.email"),
         '_label -> "Email"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContactDetails.digitalContactDetails.mobileNumber"),
         '_label -> "Mobile number"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContactDetails.digitalContactDetails.phoneNumber"),
         '_label -> "Phone number"
         )
@@ -41,43 +41,43 @@
 
     <h2>Address</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.line1"),
         '_label -> "Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.line2"),
         '_label -> "Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.line3"),
         '_label -> "Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.line4"),
         '_label -> "Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.postCode"),
         '_label -> "Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.country"),
         '_label -> "Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("correspondenceAddress.auditRef"),
         '_label -> "Address Audit Ref (optional)"
         )

--- a/app/views/pages/test/payeRegPAYEContactSetup.scala.html
+++ b/app/views/pages/test/payeRegPAYEContactSetup.scala.html
@@ -1,11 +1,11 @@
 @import models.api.{PAYEContact => PAYEContactAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import helpers.templates.inlineDateInput
+@import helpers.templates.{inlineDateInput, payeErrorSummary}
 @import pages.test.testHelpers.manualPrePopulatedInput
 
 @(payeForm: Form[PAYEContactAPI])(implicit request: Request[_], messages: Messages)
 
-@govHelpers.errorSummary(
+@payeErrorSummary(
     Messages("app.common.errorSummaryLabel"), payeForm
 )
 

--- a/app/views/pages/test/payeRegPAYEContactSetup.scala.html
+++ b/app/views/pages/test/payeRegPAYEContactSetup.scala.html
@@ -1,6 +1,6 @@
 @import models.api.{PAYEContact => PAYEContactAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import helpers.templates.{inlineDateInput, payeErrorSummary, payInput}
+@import helpers.templates.{inlineDateInput, payeErrorSummary, payeInput}
 @import pages.test.testHelpers.manualPrePopulatedInput
 
 @(payeForm: Form[PAYEContactAPI])(implicit request: Request[_], messages: Messages)
@@ -15,25 +15,25 @@
 
     <h2>Name and tel etc.</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContactDetails.name"),
         '_label -> "Contact name"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContactDetails.digitalContactDetails.email"),
         '_label -> "Email"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContactDetails.digitalContactDetails.mobileNumber"),
         '_label -> "Mobile number"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContactDetails.digitalContactDetails.phoneNumber"),
         '_label -> "Phone number"
         )
@@ -41,43 +41,43 @@
 
     <h2>Address</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.line1"),
         '_label -> "Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.line2"),
         '_label -> "Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.line3"),
         '_label -> "Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.line4"),
         '_label -> "Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.postCode"),
         '_label -> "Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.country"),
         '_label -> "Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("correspondenceAddress.auditRef"),
         '_label -> "Address Audit Ref (optional)"
         )

--- a/app/views/pages/test/payeRegistrationSetup.scala.html
+++ b/app/views/pages/test/payeRegistrationSetup.scala.html
@@ -1,11 +1,11 @@
-@import helpers.templates.inlineDateInput
+@import helpers.templates.{inlineDateInput, payeErrorSummary}
 @import models.api.{PAYERegistration => PAYERegistrationAPI}
 @import pages.test.testHelpers.manualPrePopulatedInput
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @(payeForm: Form[PAYERegistrationAPI], regID: String, txID: String)(implicit request: Request[_], messages: Messages)
 
-@govHelpers.errorSummary(
+@payeErrorSummary(
     Messages("app.common.errorSummaryLabel"), payeForm
 )
 

--- a/app/views/pages/test/payeRegistrationSetup.scala.html
+++ b/app/views/pages/test/payeRegistrationSetup.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{inlineDateInput, payeErrorSummary, payInput}
+@import helpers.templates.{inlineDateInput, payeErrorSummary, payeInput}
 @import models.api.{PAYERegistration => PAYERegistrationAPI}
 @import pages.test.testHelpers.manualPrePopulatedInput
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
@@ -29,34 +29,34 @@
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("formCreationTimestamp"),
         '_label -> "Form Creation Timestamp"
         )
     </div>
 
     <div class="inline form-group">
-    @payInput(
-        payeForm("status"),
-        '_label -> "Status"
-    )
+        @payeInput(
+            payeForm("status"),
+            '_label -> "Status"
+        )
     </div>
 
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("completionCapacity"),
         '_label -> "Completion capacity"
         )
     </div>
 
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.companyName"),
         '_label -> "Company name"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.tradingName"),
         '_label -> "Trading name (optional)"
         )
@@ -64,43 +64,43 @@
 
     <h2>RO Address</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.line1"),
         '_label -> "RO Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.line2"),
         '_label -> "RO Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.line3"),
         '_label -> "RO Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.line4"),
         '_label -> "RO Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.postCode"),
         '_label -> "RO Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.country"),
         '_label -> "RO Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.roAddress.auditRef"),
         '_label -> "RO Address Audit Ref (optional)"
         )
@@ -108,81 +108,81 @@
 
     <h2>PPOB Address</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.line1"),
         '_label -> "PPOB Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.line2"),
         '_label -> "PPOB Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.line3"),
         '_label -> "PPOB Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.line4"),
         '_label -> "PPOB Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.postCode"),
         '_label -> "PPOB Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.country"),
         '_label -> "PPOB Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("companyDetails.ppobAddress.auditRef"),
         '_label -> "PPOB Address Audit Ref (optional)"
         )
     </div>
 
     <div class="inline form-group">
-    @payInput(
+    @payeInput(
         payeForm("companyDetails.businessContactDetails.businessEmail"),
         '_label -> "Business email (optional)"
     )
     </div>
     <div class="inline form-group">
-    @payInput(
+    @payeInput(
         payeForm("companyDetails.businessContactDetails.mobileNumber"),
         '_label -> "Mobile number (optional)"
     )
     </div>
     <div class="inline form-group">
-    @payInput(
+    @payeInput(
         payeForm("companyDetails.businessContactDetails.phoneNumber"),
         '_label -> "Business telephone (optional)"
     )
     </div>
 
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("employment.employees"),
         '_label -> "Employees"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("employment.companyPension"),
         '_label -> "Company Pension (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("employment.subcontractors"),
         '_label -> "Subcontractors"
         )
@@ -197,7 +197,7 @@
 
     <h2>Nature of Business</h2>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("sicCodes[0].description"),
         '_label -> "SIC Code description (optional)"
         )
@@ -206,93 +206,93 @@
     <h2>Director Details</h2>
     <h3>Director 1</h3>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[0].name.firstName"),
         '_label -> "Firstname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[0].name.middleName"),
         '_label -> "Middlename (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[0].name.lastName"),
         '_label -> "Lastname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[0].name.title"),
         '_label -> "Title (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[0].nino"),
         '_label -> "Nino (optional)"
         )
     </div>
     <h3>Director 2</h3>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[1].name.firstName"),
         '_label -> "Firstname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[1].name.middleName"),
         '_label -> "Middlename (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[1].name.lastName"),
         '_label -> "Lastname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[1].name.title"),
         '_label -> "Title (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[1].nino"),
         '_label -> "Nino (optional)"
         )
     </div>
     <h3>Director 3</h3>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[2].name.firstName"),
         '_label -> "Firstname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[2].name.middleName"),
         '_label -> "Middlename (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[2].name.lastName"),
         '_label -> "Lastname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[2].name.title"),
         '_label -> "Title (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("directors[2].nino"),
         '_label -> "Nino (optional)"
         )
@@ -301,68 +301,68 @@
     <h3>PAYE Contact Details</h3>
     <h4>Name and tel etc.</h4>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
             payeForm("payeContact.payeContactDetails.name"),
             '_label -> "Contact name"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
             payeForm("payeContact.payeContactDetails.digitalContactDetails.email"),
             '_label -> "Email"
         )
     </div>
     <div class="inline form-group">
-    @payInput(
+    @payeInput(
         payeForm("payeContact.payeContactDetails.digitalContactDetails.mobileNumber"),
         '_label -> "Mobile number"
     )
     </div>
     <div class="inline form-group">
-    @payInput(
+    @payeInput(
         payeForm("payeContact.payeContactDetails.digitalContactDetails.phoneNumber"),
         '_label -> "Phone number"
     )
     </div>
     <h4>Address</h4>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.line1"),
         '_label -> "PAYE Correspondence Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.line2"),
         '_label -> "PAYE Correspondence Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.line3"),
         '_label -> "PAYE Correspondence Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.line4"),
         '_label -> "PAYE Correspondence Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.postCode"),
         '_label -> "PAYE Correspondence Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.country"),
         '_label -> "PAYE Correspondence Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @payInput(
+        @payeInput(
         payeForm("payeContact.correspondenceAddress.auditRef"),
         '_label -> "Correspondence Address Audit Ref (optional)"
         )

--- a/app/views/pages/test/payeRegistrationSetup.scala.html
+++ b/app/views/pages/test/payeRegistrationSetup.scala.html
@@ -1,4 +1,4 @@
-@import helpers.templates.{inlineDateInput, payeErrorSummary}
+@import helpers.templates.{inlineDateInput, payeErrorSummary, payInput}
 @import models.api.{PAYERegistration => PAYERegistrationAPI}
 @import pages.test.testHelpers.manualPrePopulatedInput
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
@@ -29,34 +29,34 @@
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("formCreationTimestamp"),
         '_label -> "Form Creation Timestamp"
         )
     </div>
 
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         payeForm("status"),
         '_label -> "Status"
     )
     </div>
 
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("completionCapacity"),
         '_label -> "Completion capacity"
         )
     </div>
 
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.companyName"),
         '_label -> "Company name"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.tradingName"),
         '_label -> "Trading name (optional)"
         )
@@ -64,43 +64,43 @@
 
     <h2>RO Address</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.line1"),
         '_label -> "RO Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.line2"),
         '_label -> "RO Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.line3"),
         '_label -> "RO Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.line4"),
         '_label -> "RO Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.postCode"),
         '_label -> "RO Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.country"),
         '_label -> "RO Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.roAddress.auditRef"),
         '_label -> "RO Address Audit Ref (optional)"
         )
@@ -108,81 +108,81 @@
 
     <h2>PPOB Address</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.line1"),
         '_label -> "PPOB Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.line2"),
         '_label -> "PPOB Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.line3"),
         '_label -> "PPOB Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.line4"),
         '_label -> "PPOB Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.postCode"),
         '_label -> "PPOB Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.country"),
         '_label -> "PPOB Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("companyDetails.ppobAddress.auditRef"),
         '_label -> "PPOB Address Audit Ref (optional)"
         )
     </div>
 
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         payeForm("companyDetails.businessContactDetails.businessEmail"),
         '_label -> "Business email (optional)"
     )
     </div>
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         payeForm("companyDetails.businessContactDetails.mobileNumber"),
         '_label -> "Mobile number (optional)"
     )
     </div>
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         payeForm("companyDetails.businessContactDetails.phoneNumber"),
         '_label -> "Business telephone (optional)"
     )
     </div>
 
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("employment.employees"),
         '_label -> "Employees"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("employment.companyPension"),
         '_label -> "Company Pension (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("employment.subcontractors"),
         '_label -> "Subcontractors"
         )
@@ -197,7 +197,7 @@
 
     <h2>Nature of Business</h2>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("sicCodes[0].description"),
         '_label -> "SIC Code description (optional)"
         )
@@ -206,93 +206,93 @@
     <h2>Director Details</h2>
     <h3>Director 1</h3>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[0].name.firstName"),
         '_label -> "Firstname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[0].name.middleName"),
         '_label -> "Middlename (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[0].name.lastName"),
         '_label -> "Lastname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[0].name.title"),
         '_label -> "Title (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[0].nino"),
         '_label -> "Nino (optional)"
         )
     </div>
     <h3>Director 2</h3>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[1].name.firstName"),
         '_label -> "Firstname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[1].name.middleName"),
         '_label -> "Middlename (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[1].name.lastName"),
         '_label -> "Lastname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[1].name.title"),
         '_label -> "Title (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[1].nino"),
         '_label -> "Nino (optional)"
         )
     </div>
     <h3>Director 3</h3>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[2].name.firstName"),
         '_label -> "Firstname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[2].name.middleName"),
         '_label -> "Middlename (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[2].name.lastName"),
         '_label -> "Lastname (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[2].name.title"),
         '_label -> "Title (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("directors[2].nino"),
         '_label -> "Nino (optional)"
         )
@@ -301,68 +301,68 @@
     <h3>PAYE Contact Details</h3>
     <h4>Name and tel etc.</h4>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
             payeForm("payeContact.payeContactDetails.name"),
             '_label -> "Contact name"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
             payeForm("payeContact.payeContactDetails.digitalContactDetails.email"),
             '_label -> "Email"
         )
     </div>
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         payeForm("payeContact.payeContactDetails.digitalContactDetails.mobileNumber"),
         '_label -> "Mobile number"
     )
     </div>
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         payeForm("payeContact.payeContactDetails.digitalContactDetails.phoneNumber"),
         '_label -> "Phone number"
     )
     </div>
     <h4>Address</h4>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.line1"),
         '_label -> "PAYE Correspondence Address Line 1"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.line2"),
         '_label -> "PAYE Correspondence Address Line 2"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.line3"),
         '_label -> "PAYE Correspondence Address Line 3 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.line4"),
         '_label -> "PAYE Correspondence Address Line 4 (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.postCode"),
         '_label -> "PAYE Correspondence Address Postcode (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.country"),
         '_label -> "PAYE Correspondence Address Country (optional)"
         )
     </div>
     <div class="inline form-group">
-        @govHelpers.input(
+        @payInput(
         payeForm("payeContact.correspondenceAddress.auditRef"),
         '_label -> "Correspondence Address Audit Ref (optional)"
         )

--- a/app/views/pages/test/testHelpers/manualPrePopulatedInput.scala.html
+++ b/app/views/pages/test/testHelpers/manualPrePopulatedInput.scala.html
@@ -12,7 +12,7 @@
 @labelHighlight = @{ elements.args.get('_labelHighlight).getOrElse(false).asInstanceOf[Boolean] }
 
 
-<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-field--error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
+<label for="@elements.field.name" class="@elements.args.get('_divClass) @if( elements.args.get('_labelClass) ){ @elements.args.get('_labelClass) } @if(elements.hasErrors || (parentElements.isDefined && parentElements.get.hasErrors)) {form-group-error}" @if(elements.args.contains('_labelDataAttributes)){@elements.args.get('_labelDataAttributes)}>
 
 @if(!elements.args.contains('_hideErrors)) {
 @elements.errors.map { error =>

--- a/app/views/pages/test/updateCCPage.scala.html
+++ b/app/views/pages/test/updateCCPage.scala.html
@@ -1,5 +1,5 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
-@import helpers.templates.payInput
+@import helpers.templates.payeInput
 
 @import models.test.TestCC
 
@@ -10,7 +10,7 @@
 @govHelpers.form(action = controllers.test.routes.TestCCController.submitUpdateCC) {
     <h2>Director, agent or other</h2>
     <div class="inline form-group">
-    @payInput(
+    @payeInput(
         testCCForm("cc"),
         '_label -> "Completion Capacity"
     )

--- a/app/views/pages/test/updateCCPage.scala.html
+++ b/app/views/pages/test/updateCCPage.scala.html
@@ -1,4 +1,5 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
+@import helpers.templates.payInput
 
 @import models.test.TestCC
 
@@ -9,7 +10,7 @@
 @govHelpers.form(action = controllers.test.routes.TestCCController.submitUpdateCC) {
     <h2>Director, agent or other</h2>
     <div class="inline form-group">
-    @govHelpers.input(
+    @payInput(
         testCCForm("cc"),
         '_label -> "Completion Capacity"
     )

--- a/public/javascripts/paye.js
+++ b/public/javascripts/paye.js
@@ -4,7 +4,7 @@ $(document).ready($(function() {
     function changeHrefForFirefox() {
         var isFirefox = typeof InstallTrigger !== 'undefined';
         if (isFirefox) {
-            $(".js-error-summary-messages a").each(function (index, object) {
+            $(".error-summary-list a").each(function (index, object) {
                 var element = $(object).attr("data-focuses");
 
                 // Matches 1 or more characters at the start of the string followed by [ followed by one or more numbers, followed by ]

--- a/public/stylesheets/form-validation.css
+++ b/public/stylesheets/form-validation.css
@@ -1,0 +1,145 @@
+/* Form validation */
+/*
+  #b10e1e and #ffbf47 = current GOV.UK $error-colour ansd $focus-colour
+  https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss
+*/
+/* ========================================================================== */
+
+/* Use .form-group-error to add a red border to the left of a .form-group */
+.form-group-error {
+  margin-right: 15px;
+  border-left: 4px solid #b10e1e;
+  padding-left: 10px;
+}
+
+
+@media (min-width: 641px) {
+  .form-group-error  {
+    border-left: 5px solid #b10e1e;
+    padding-left: 15px;
+  }  
+}
+
+/* Use .form-control-error to add a red border to .form-control */
+.form-control-error {
+  border: 4px solid #b10e1e;
+}
+
+
+/* Error messages should be red and bold */
+.error-message {
+  font-size: 16px;
+  color: #b10e1e;
+
+
+  display: block;
+  clear: both;
+
+  margin: 0;
+  padding: 2px 0;
+}
+
+@media (min-width: 641px) {
+  .error-message {
+    font-size: 19px;
+  }
+}
+
+.form-label .error-message,
+.form-label-bold .error-message {
+  padding-top: 4px;
+  padding-bottom: 0;
+}
+
+/* Summary of multiple error messages */
+.error-summary {
+
+  /* Error summary has a border on all sides */
+  border: 4px solid #b10e1e;
+
+  margin-top: 15px;
+  margin-bottom: 15px;
+
+  padding: 15px 10px;
+
+/*  @include ie-lte(6) {
+    zoom: 1;
+  }*/
+}
+
+@media (min-width: 641px) {
+  .error-summary {
+    border: 5px solid #b10e1e;
+
+    margin-top: 30px;
+    margin-bottom: 30px;
+
+    padding: 20px 15px 15px;
+  }
+}
+
+/* Use the GOV.UK outline focus style */
+.error-summary:focus {
+  outline: 3px solid #ffbf47;
+}
+
+.error-summary .error-summary-heading {
+  margin-top: 0;
+}
+
+.error-summary p {
+  margin-bottom: 10px;
+}
+
+.error-summary .error-summary-list {
+  padding-left: 0;
+}
+
+@media (min-width: 641px) {
+  .error-summary .error-summary-list li {
+    margin-bottom: 5px;
+  }
+}
+
+.error-summary .error-summary-list a {
+  color: #b10e1e;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+
+
+.error-notification {
+  font-size: 16px;
+  font-weight: bold;
+  color: #b10e1e;
+  display: block;
+}
+
+@media (min-width: 641px) {
+  .error-notification {
+    font-size: 19px;
+  }
+}
+
+
+
+
+/*
+  Removes bottom margin from last .block-label element so that the left error border lines up with the bottom of the content,
+  This is a temporary fix before we upgrade to latest radio buttons and checkboxes.
+  Which uses the multiple-choice class that has css that does this
+
+  The code below can be deleted when we bump play-ui and HMRC AF to adopt the new radio buttons and checkboxes
+*/
+@media (min-width: 641px) {
+  .block-label:last-of-type,
+  .block-label:last-child {
+    margin: 0;
+  }
+}
+
+.form-field:last-of-type,
+.form-field:last-child {
+    margin-bottom: 0;
+}

--- a/public/stylesheets/paye.css
+++ b/public/stylesheets/paye.css
@@ -1,18 +1,8 @@
 @import 'global-header.css';
+@import 'form-validation.css';
 
 /* position labels above input fields in cascading forms */
 label.cascading span {
-	display: block;
-}
-
-
-/* hide error summary */
-.error-summary {
-	display: none;
-}
-
-/* show error summary when required */
-.error-summary--show  {
 	display: block;
 }
 


### PR DESCRIPTION
Error messaging is failing accessibility because of the lighter red coloured font on the white background didn't have enough contrast.

This change also includes updating the transaction completion header with the turquoise background because that also fails accessibility.
However, the styles for this will shortly be merged into HMRC AF. When they are I will create PR's removing the local styles that are included here.

In this commit:
• updated all instances of classes required for the new styling changes
• removed unnecessary styles from paye.css
• updated markpup for transaction completion header
• added local styles for transaction completion header
(to be removed once merged into HMRC AF)
• added local styles for error/form validation
• updated pages to use local error summary helper
• created local helper for input, to include new classes
• Added div class="form-group" to wrap from in directorDetails.scala.html
page to fix broken layout issue

NOTE: The latest commit removes local assets for components because they are now part of HMRC AF https://github.com/hmrc/paye-registration-frontend/pull/274/commits/aa6fcc17ce18ffeb9f06123e656ae2d7774662e0

## Error message style update example
### Before
<img width="1026" alt="screen shot 2017-09-18 at 09 51 37" src="https://user-images.githubusercontent.com/1692222/30534789-9c2c98d0-9c57-11e7-92a9-d50cbfa5eca1.png">

### After
<img width="1012" alt="screen shot 2017-09-18 at 09 50 49" src="https://user-images.githubusercontent.com/1692222/30534802-aa6a6710-9c57-11e7-9682-cd59c7a96a70.png">

## Transaction completion header update
### Before
<img width="1011" alt="screen shot 2017-09-18 at 09 52 41" src="https://user-images.githubusercontent.com/1692222/30534820-c03fb40a-9c57-11e7-84f2-66d5c47193a8.png">

### After
<img width="1012" alt="screen shot 2017-09-18 at 09 54 56" src="https://user-images.githubusercontent.com/1692222/30534831-ccce001e-9c57-11e7-805e-0b4c514dac6d.png">

