### PR TITLE
Remove superfluous content wrapper and bump to latest AF v2.252.0

### DIFF
--- a/app/views/pages/welcome.scala.html
+++ b/app/views/pages/welcome.scala.html
@@ -4,10 +4,6 @@
 
 @main_template(title = Messages("pages.welcome.title")) {
 
-
-<div class="grid-row">
-    <div class="column-one-third">
-
         <header class="page-header">
             <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.welcome.heading")</h1>
         </header>
@@ -28,25 +24,13 @@
         </ul>
         <p id="cost spaced-below">@Messages("pages.welcome.2months")</p>
 
-
-
         @form(action = controllers.userJourney.routes.WelcomeController.submit()) {
-        <div class="form-group spaced-above">
-            <button class="button-get-started" role="button" id="continue">@Messages("app.common.startNow")</button>
-        </div>
+            <div class="form-group spaced-above">
+                <button class="button-get-started" role="button" id="continue">@Messages("app.common.startNow")</button>
+            </div>
         }
 
         <h2>@Messages("pages.welcome.beforeStart")</h2>
-
-
         <p id="nino spaced-below">@Messages("pages.welcome.nino")</p>
-
         <p id="nino spaced-below">@Messages("pages.welcome.application")</p>
-
-
-
-
-    </div>
-
-</div>
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -171,7 +171,7 @@ google-analytics {
 }
 
 assets {
-  version = "2.241.0"
+  version = "2.252.0"
   version = ${?ASSETS_FRONTEND_VERSION}
   url = "http://localhost:9032/assets/"
 }


### PR DESCRIPTION
The removal of .grid-row and .column-one-third removes any
potential of these content wrappers breaking layout. They do nothing
but if they dod pick up the correct styles then they would break
layout. There's no need for them, hence - removed.

Bump to latest HMRC AF version 2.252.0, which contains some minor
styling fixes such as, correct padding for continue buttons,
correct border thickness for text inputs, correct styles and
firefox for year date input field, among other changes.