### PR TITLE
Review, add and update legends and refactor messages.

### DIFF
--- a/app/connectors/AddressLookupConnector.scala
+++ b/app/connectors/AddressLookupConnector.scala
@@ -95,14 +95,14 @@ trait AddressLookupConnect {
         submitLabel = messagesApi(s"pages.alf.common.lookupPage.submitLabel")
       ),
       selectPage = SelectPage(
-        title = messagesApi(s"pages.alf.common.selectPage.title"),
-        heading = messagesApi(s"pages.alf.common.selectPage.heading"),
+        title = messagesApi(s"pages.alf.common.selectPage.description"),
+        heading = messagesApi(s"pages.alf.common.selectPage.description"),
         proposalListLimit = proposalListLimit,
         showSearchAgainLink = showSearchAgainLink
       ),
       editPage = EditPage(
-        title = messagesApi(s"pages.alf.common.editPage.title"),
-        heading = messagesApi(s"pages.alf.common.editPage.heading"),
+        title = messagesApi(s"pages.alf.common.editPage.description"),
+        heading = messagesApi(s"pages.alf.common.editPage.description"),
         line1Label = messagesApi(s"pages.alf.common.editPage.line1Label"),
         line2Label = messagesApi(s"pages.alf.common.editPage.line2Label"),
         line3Label = messagesApi(s"pages.alf.common.editPage.line3Label"),

--- a/app/views/feedback.scala.html
+++ b/app/views/feedback.scala.html
@@ -19,6 +19,6 @@
 @(partialUrl : String, formBody : Option[Html])(implicit request : Request[_], formPartialRetriever: FormPartialRetriever,
 partialRetriever: FormPartialRetriever, messages: Messages)
 
-@main_template(title = Messages("page.feedback.title"), bodyClasses = None) {
+@main_template(title = Messages("page.feedback.description"), bodyClasses = None) {
     @formBody.getOrElse(formPartialRetriever.getPartialContent(partialUrl))
 }

--- a/app/views/feedback_thankyou.scala.html
+++ b/app/views/feedback_thankyou.scala.html
@@ -19,7 +19,7 @@
 @(partialUrl: String, redirectUrl: String)(implicit request: Request[_], cachedStaticHtmlPartialRetriever: CachedStaticHtmlPartialRetriever,
 messages: Messages)
 
-@main_template(Messages("page.feedback.thank-you.title")) {
+@main_template(Messages("page.feedback.thank-you")) {
     @cachedStaticHtmlPartialRetriever.getPartialContent(partialUrl)
     <a id="back" href='@redirectUrl' role="button" tabindex="0" class="button">@Messages("app.common.back")</a>
 }

--- a/app/views/helpers/templates/inlineDateInput.scala.html
+++ b/app/views/helpers/templates/inlineDateInput.scala.html
@@ -10,6 +10,10 @@
 
 <fieldset class="form-group form-date @fieldsetClasses" id="@fieldName-fieldset">
 
+    @{args.filter(a => a._1.name == "_legend").map { a =>
+        <legend class="visually-hidden">{a._2.toString}</legend>
+    }}
+
     @if(formItem.hasErrors) {
     @formItem.errors.filter(_.key.contains(fieldName)).map { error => <span class="error-notification" id='@{s"${error.key}-error-message"}'>@Messages(s"${error.message}")</span>}
     }
@@ -20,7 +24,7 @@
     formItem(s"${fieldName}Day"),
     '_label -> Messages("app.common.day"),
     '_labelClass -> "form-group form-group-day",
-    '_type -> "number",
+    '_type -> "tel",
     '_inputClass -> s"input--xxsmall input--no-spinner",
     '_maxlength -> "2"
     )
@@ -29,7 +33,7 @@
     formItem(s"${fieldName}Month"),
     '_label -> Messages("app.common.month"),
     '_labelClass -> "form-group form-group-month",
-    '_type -> "number",
+    '_type -> "tel",
     '_inputClass -> s"input--xxsmall input--no-spinner",
     '_maxlength -> "2"
     )
@@ -38,7 +42,7 @@
     formItem(s"${fieldName}Year"),
     '_label -> Messages("app.common.year"),
     '_labelClass -> "form-group form-group-year",
-    '_type -> "number",
+    '_type -> "tel",
     '_inputClass -> s"input--small input--no-spinner",
     '_maxlength -> "4"
     )

--- a/app/views/helpers/templates/payeInputRadioGroup.scala.html
+++ b/app/views/helpers/templates/payeInputRadioGroup.scala.html
@@ -9,7 +9,7 @@
 <fieldset class="@fieldsetClass" id="@field.id"
           @if(elements.args.get('_fieldsetAttributes).isDefined) {@elements.args.get('_fieldsetAttributes)}>
     @if(elements.args.get('_legend).isDefined) {
-        <legend class="visuallyhidden" @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}>
+        <legend class="visually-hidden" @if(elements.args.get('_legendClass).isDefined) {class="@elements.args.get('_legendClass)"}>
             @elements.args.get('_legend)
         </legend>
     }

--- a/app/views/helpers/templates/summaryRow.scala.html
+++ b/app/views/helpers/templates/summaryRow.scala.html
@@ -19,7 +19,7 @@
   <dd class="cya-change">
     @row.changeLink.map { linkLocation =>
       <a href="@linkLocation" id="@{row.id}ChangeLink">@Messages("app.common.change")
-      <span class ="visuallyhidden" id="@{row.id}HelpText">&nbsp; @Messages(s"pages.summary.${row.id}.hiddenChangeText")</span></a>
+      <span class ="visually-hidden" id="@{row.id}HelpText">&nbsp; @Messages(s"pages.summary.${row.id}.hiddenChangeText")</span></a>
     }
   </dd>
 </div>

--- a/app/views/pages/companyDetails/businessContactDetails.scala.html
+++ b/app/views/pages/companyDetails/businessContactDetails.scala.html
@@ -5,8 +5,8 @@
 
 @formContent = {
     <fieldset>
-        <legend class="visuallyhidden">
-            @Messages("pages.businessContact.heading")
+        <legend class="visually-hidden">
+            @Messages("pages.businessContact.description")
         </legend>
         <div class="form-group">
             @payeInput(
@@ -37,13 +37,13 @@
     </fieldset>
 }
 
-@main_template(title = messages("pages.businessContact.title")) {
+@main_template(title = messages("pages.businessContact.description")) {
 
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), contactForm, dataJourney=Some("DigitalContactDetails")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.businessContact.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.businessContact.description")</h1>
 
     @govHelpers.form(action = controllers.userJourney.routes.CompanyDetailsController.submitBusinessContactDetails()) {
 

--- a/app/views/pages/companyDetails/confirmROAddress.scala.html
+++ b/app/views/pages/companyDetails/confirmROAddress.scala.html
@@ -5,9 +5,9 @@
 
 @(companyName : String, address : Address)(implicit request: Request[_], messages: Messages)
 
-@main_template(title = messages("pages.confirmRO.title")) {
+@main_template(title = messages("pages.confirmRO.description")) {
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Html(messages("pages.confirmRO.heading"))</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Html(messages("pages.confirmRO.description"))</h1>
 
     <p id="lead-paragraph">@messages("pages.confirmRO.lede", companyName)</p>
 

--- a/app/views/pages/companyDetails/ppobAddress.scala.html
+++ b/app/views/pages/companyDetails/ppobAddress.scala.html
@@ -5,12 +5,12 @@
 
 @(chooseAddressForm: Form[ChosenAddress], roAddress: Option[Address], ppobAddress: Option[Address], prepopAddresses: Map[Int, Address])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = messages("pages.ppobAddress.title")) {
+@main_template(title = messages("pages.ppobAddress.description")) {
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), chooseAddressForm, dataJourney=Some("PPOBAddress")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.ppobAddress.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.ppobAddress.description")</h1>
        <p>@Messages("pages.ppobAddress.peopleIntro1")</p>
        <p>@Messages("pages.ppobAddress.peopleIntro2")</p>
 
@@ -24,7 +24,7 @@
                 ).flatten.++(
                     prepopAddresses.map {case (k, v) => s"${PrepopAddress.prefix}$k" -> addressDisplay(v, s"${PrepopAddress.prefix.toLowerCase}$k").toString}.toList
                 ).:+("other" -> messages("pages.ppobAddress.other")),
-                '_legend -> messages("pages.ppobAddress.legend"),
+                '_legend -> messages("pages.ppobAddress.description"),
                 '_legendID -> "chosenAddress",
                 '_helpText -> None,
                 '_labelAfter -> true,

--- a/app/views/pages/companyDetails/tradingName.scala.html
+++ b/app/views/pages/companyDetails/tradingName.scala.html
@@ -27,13 +27,13 @@
     </ul>
 }
 
-@main_template(title = Messages("pages.tradingName.title")) {
+@main_template(title = Messages("pages.tradingName.description")) {
 
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), tradingNameForm, dataJourney=Some("TradingName")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.tradingName.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.tradingName.description")</h1>
 
 
      <p id="lead-paragraph">@messages("pages.tradingName.lede", companyName)</p>
@@ -46,7 +46,7 @@
         @formHiddenYesNoRadio(
             tradingNameForm,
             "differentName",
-            Messages("pages.tradingName.legend"),
+            Messages("pages.tradingName.description"),
             hiddenYesNoContent
         )
 

--- a/app/views/pages/completionCapacity.scala.html
+++ b/app/views/pages/completionCapacity.scala.html
@@ -13,13 +13,13 @@
     )
 }
 
-@main_template(title = messages("pages.completionCapacity.title")) {
+@main_template(title = messages("pages.completionCapacity.description")) {
 
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), completionCapacityForm, dataJourney=Some("CompletionCapacity")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.completionCapacity.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@messages("pages.completionCapacity.description")</h1>
 
     @govHelpers.form(action = controllers.userJourney.routes.CompletionCapacityController.submitCompletionCapacity()) {
 
@@ -34,8 +34,8 @@
                 '_idHidden -> "other",
                 '_classHidden -> "panel panel-indent",
                 '_labelClass -> "block-label radio-label",
-                '_legend -> Messages("pages.completionCapacity.legend"),
-                '_legendClass -> "visuallyhidden"
+                '_legend -> Messages("pages.completionCapacity.description"),
+                '_legendClass -> "visually-hidden"
             )
         </div>
 

--- a/app/views/pages/confirmation.scala.html
+++ b/app/views/pages/confirmation.scala.html
@@ -1,9 +1,9 @@
 @(ackRef: String)(implicit request: Request[_], messages: Messages)
 
-@main_template(title = messages("pages.confirmation.title"), backButton = false) {
+@main_template(title = messages("pages.confirmation.description"), backButton = false) {
 
     <div class="govuk-box-highlight">
-        <h1 class="heading-xlarge" id="pageHeading">@messages("pages.confirmation.heading")</h1>
+        <h1 class="heading-xlarge" id="pageHeading">@messages("pages.confirmation.description")</h1>
         <p class="font-large">
             @messages("pages.confirmation.reference")
             <br>

--- a/app/views/pages/directorDetails.scala.html
+++ b/app/views/pages/directorDetails.scala.html
@@ -7,7 +7,7 @@
 
 @formContent = {
     <fieldset>
-        <legend class="visuallyhidden">@messages("pages.directorDetails.legend")</legend>
+        <legend class="visually-hidden">@messages("pages.directorDetails.description")</legend>
 
         @helper.repeat(ninoForm("nino")) { ninoField =>
             <div class="form-field">
@@ -36,13 +36,13 @@
     </p>
 }
 
-@main_template(title = messages(s"pages.directorDetails.title")) {
+@main_template(title = messages(s"pages.directorDetails.description")) {
 
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), ninoForm, dataJourney=Some("DirectorNINOs")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Html(messages(s"pages.directorDetails.heading"))</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Html(messages(s"pages.directorDetails.description"))</h1>
 
     <div class="form-group">
         @hiddenDetails("directors", Messages("pages.directorDetails.information.dropdown.header"), hiddenDetailsContent)

--- a/app/views/pages/eligibility/companyEligibility.scala.html
+++ b/app/views/pages/eligibility/companyEligibility.scala.html
@@ -4,11 +4,11 @@
 
 @(companyEligibilityForm: Form[CompanyEligibility])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("pages.companyEligibility.title")) {
+@main_template(title = Messages("pages.companyEligibility.description")) {
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), companyEligibilityForm, dataJourney=Some("CompanyEligibility")
     )
-    <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.companyEligibility.heading")</h1>
+    <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.companyEligibility.description")</h1>
 
      @govHelpers.form(action = controllers.userJourney.routes.EligibilityController.submitCompanyEligibility()) {
         <div class="inline form-group">
@@ -18,7 +18,7 @@
                     "true"->Messages("app.common.yes"),
                     "false"->Messages("app.common.no")
                 ),
-                '_legend -> Messages("pages.companyEligibility.heading"),
+                '_legend -> Messages("pages.companyEligibility.description"),
                 '_legendID -> "companyEligibility",
                 '_helpText -> None,
                 '_labelAfter -> true,

--- a/app/views/pages/eligibility/directorEligibility.scala.html
+++ b/app/views/pages/eligibility/directorEligibility.scala.html
@@ -4,11 +4,11 @@
 
 @(directorEligibilityForm: Form[DirectorEligibility])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("pages.directorEligibility.title")) {
+@main_template(title = Messages("pages.directorEligibility.description")) {
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), directorEligibilityForm, dataJourney=Some("DirectorEligibility")
     )
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.directorEligibility.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.directorEligibility.description")</h1>
 
     <p>@Messages("pages.employingStaff.directorEligibilityRulesIntro1")</p>
     <p>@Messages("pages.employingStaff.directorEligibilityRulesIntro2")</p>
@@ -28,7 +28,7 @@
                 "true"->Messages("app.common.yes"),
                 "false"->Messages("app.common.no")
             ),
-            '_legend -> Messages("pages.directorEligibility.heading"),
+            '_legend -> Messages("pages.directorEligibility.description"),
             '_legendID -> "directorEligibility",
             '_helpText -> None,
             '_labelAfter -> true,

--- a/app/views/pages/eligibility/ineligible.scala.html
+++ b/app/views/pages/eligibility/ineligible.scala.html
@@ -3,9 +3,9 @@
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import helpers.templates.linkNewWindow
 
-@main_template(title = Messages("pages.ineligible.title")) {
+@main_template(title = Messages("pages.ineligible.description")) {
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.ineligible.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.ineligible.description")</h1>
 
     <p>@Messages("pages.ineligible.p1")</p>
 

--- a/app/views/pages/employmentDetails/companyPension.scala.html
+++ b/app/views/pages/employmentDetails/companyPension.scala.html
@@ -4,12 +4,12 @@
 
 @(companyPensionForm: Form[CompanyPension])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("pages.companyPension.title")) {
+@main_template(title = Messages("pages.companyPension.description")) {
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), companyPensionForm, dataJourney=Some("CompanyPension")
     )
 
-    <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.companyPension.heading")</h1>
+    <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.companyPension.description")</h1>
 
     @govHelpers.form(action = controllers.userJourney.routes.EmploymentController.submitCompanyPension) {
 
@@ -27,7 +27,7 @@
                     "true"->Messages("app.common.yes"),
                     "false"->Messages("app.common.no")
                 ),
-                '_legend -> Messages("pages.companyPension.legend"),
+                '_legend -> Messages("pages.companyPension.description"),
                 '_legendID -> "companyPension",
                 '_helpText -> None,
                 '_labelAfter -> true,

--- a/app/views/pages/employmentDetails/employingStaff.scala.html
+++ b/app/views/pages/employmentDetails/employingStaff.scala.html
@@ -4,11 +4,11 @@
 
 @(employingStaffForm: Form[EmployingStaff])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("pages.employingStaff.title")) {
+@main_template(title = Messages("pages.employingStaff.description")) {
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), employingStaffForm, dataJourney=Some("EmployingStaff")
     )
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.employingStaff.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.employingStaff.description")</h1>
     @govHelpers.form(action = controllers.userJourney.routes.EmploymentController.submitEmployingStaff) {
         <p>@Messages("pages.employingStaff.employingStaffRulesIntro")</p>
         <ul class="list list-bullet">
@@ -24,7 +24,7 @@
                     "true"->Messages("app.common.yes"),
                     "false"->Messages("app.common.no")
                 ),
-                '_legend -> Messages("pages.employingStaff.legend"),
+                '_legend -> Messages("pages.employingStaff.description"),
                 '_legendID -> "employingStaff",
                 '_helpText -> None,
                 '_labelAfter -> true,

--- a/app/views/pages/employmentDetails/firstPayment.scala.html
+++ b/app/views/pages/employmentDetails/firstPayment.scala.html
@@ -15,11 +15,11 @@
     <p>@Messages("pages.firstPayment.firstPaymentRulesEnd")</p>
 }
 
-@main_template(title = Messages("pages.firstPayment.title")) {
+@main_template(title = Messages("pages.firstPayment.description")) {
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), firstPaymentForm, dataJourney=Some("FirstPayment")
     )
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.firstPayment.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.firstPayment.description")</h1>
     <p>@Messages("pages.firstPayment.intro")</p>
     <div class="form-group">
         <p>@Messages("pages.firstPayment.list")</p>
@@ -39,7 +39,8 @@
         @inlineDateInput(
         firstPaymentForm,
         "firstPay",
-        Some(Html(Messages("pages.firstPayment.hint")))
+        Some(Html(Messages("pages.firstPayment.hint"))),
+        '_legend -> Messages("pages.firstPayment.description")
         )
 
 

--- a/app/views/pages/employmentDetails/subcontractors.scala.html
+++ b/app/views/pages/employmentDetails/subcontractors.scala.html
@@ -5,11 +5,11 @@
 
 @(subcontractorsForm: Form[Subcontractors])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("pages.subcontractors.title")) {
+@main_template(title = Messages("pages.subcontractors.description")) {
     @payeErrorSummary(
         Messages("app.common.errorSummaryLabel"), subcontractorsForm, dataJourney=Some("Subcontractors")
     )
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.subcontractors.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.subcontractors.description")</h1>
     @govHelpers.form(action = controllers.userJourney.routes.EmploymentController.submitSubcontractors) {
         <p>@Messages("pages.subcontractors.nameRulesIntro")</p>
         <p>
@@ -23,7 +23,7 @@
                     "true"->Messages("app.common.yes"),
                     "false"->Messages("app.common.no")
                 ),
-                '_legend -> Messages("pages.subcontractors.legend"),
+                '_legend -> Messages("pages.subcontractors.description"),
                 '_legendID -> "subcontractors",
                 '_helpText -> None,
                 '_labelAfter -> true,

--- a/app/views/pages/error/deskproSubmitted.scala.html
+++ b/app/views/pages/error/deskproSubmitted.scala.html
@@ -1,8 +1,8 @@
 @()(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("errorPages.deskproSubmitted.title")) {
+@main_template(title = Messages("errorPages.deskproSubmitted.description")) {
 
-    <h1 class="heading-xlarge">@Messages("errorPages.deskproSubmitted.heading")</h1>
+    <h1 class="heading-xlarge">@Messages("errorPages.deskproSubmitted.description")</h1>
 
     <p>@Messages("errorPages.deskproSubmitted.p1")</p>
     <p>@Messages("errorPages.deskproSubmitted.p2")</p>

--- a/app/views/pages/error/ineligible.scala.html
+++ b/app/views/pages/error/ineligible.scala.html
@@ -2,9 +2,9 @@
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
-@main_template(title = Messages("errorPages.ineligible.title")) {
+@main_template(title = Messages("errorPages.ineligible.description")) {
 
-  <h1 class="heading-xlarge">@Messages("errorPages.ineligible.heading")</h1>
+  <h1 class="heading-xlarge">@Messages("errorPages.ineligible.description")</h1>
 
   <p>@Messages("errorPages.ineligible.p1")</p>
 

--- a/app/views/pages/error/restart.scala.html
+++ b/app/views/pages/error/restart.scala.html
@@ -1,8 +1,8 @@
 @()(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("errorPages.title")) {
+@main_template(title = Messages("errorPages.restart.description")) {
 
-    <h1>@Messages("errorPages.restart.heading")</h1>
+    <h1>@Messages("errorPages.restart.description")</h1>
 
     <p>@Html(Messages("errorPages.restart.p1", controllers.userJourney.routes.WelcomeController.show))</p>
 

--- a/app/views/pages/error/submissionFailed.scala.html
+++ b/app/views/pages/error/submissionFailed.scala.html
@@ -4,13 +4,13 @@
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
-@main_template(title = Messages("errorPages.failedSubmission.title")) {
+@main_template(title = Messages("errorPages.failedSubmission.description")) {
 
   @payeErrorSummary(
     messages("app.common.errorSummaryLabel"), deskproForm, dataJourney=Some("DESDeskPro")
   )
 
-  <h1 class="heading-xlarge">@Messages("errorPages.failedSubmission.title")</h1>
+  <h1 class="heading-xlarge">@Messages("errorPages.failedSubmission.description")</h1>
 
   <div class="spaced-below">
     <p>@Messages("errorPages.failedSubmission.p1")</p>
@@ -23,7 +23,7 @@
     <h2 class="section-heading">@Messages("errorPages.failedSubmission.header")</h2>
     <p class="spaced-below">@Messages("errorPages.failedSubmission.detail")</p>
     <fieldset class="form-group">
-      <legend class="visuallyhidden">@Messages("errorPages.failedSubmission.detail")</legend>
+      <legend class="visually-hidden">@Messages("errorPages.failedSubmission.p1") @Messages("errorPages.failedSubmission.p2")</legend>
         <div class="form-field">
           @payeInput(
             deskproForm("name"),

--- a/app/views/pages/error/submissionTimeout.scala.html
+++ b/app/views/pages/error/submissionTimeout.scala.html
@@ -2,9 +2,9 @@
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
-@main_template(title = Messages("errorPages.retrySubmission.title")) {
+@main_template(title = Messages("errorPages.retrySubmission.description")) {
 
-    <h1 class="heading-xlarge">@Messages("errorPages.retrySubmission.title")</h1>
+    <h1 class="heading-xlarge">@Messages("errorPages.retrySubmission.description")</h1>
 
     <p>@Messages("errorPages.retrySubmission.p1")</p>
 

--- a/app/views/pages/natureOfBusiness.scala.html
+++ b/app/views/pages/natureOfBusiness.scala.html
@@ -4,13 +4,13 @@
 
 @(sicForm: Form[NatureOfBusiness])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = messages("pages.natureOfBusiness.title")) {
+@main_template(title = messages("pages.natureOfBusiness.description")) {
 
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), sicForm, dataJourney=Some("NatureOfBusiness")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Html(messages("pages.natureOfBusiness.heading"))</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Html(messages("pages.natureOfBusiness.description"))</h1>
 
     @govHelpers.form(action = controllers.userJourney.routes.NatureOfBusinessController.submitNatureOfBusiness()) {
         <div class="form-group">

--- a/app/views/pages/payeContact/correspondenceAddress.scala.html
+++ b/app/views/pages/payeContact/correspondenceAddress.scala.html
@@ -5,12 +5,12 @@
 
 @(chooseAddressForm: Form[ChosenAddress], roAddress: Option[Address], ppobAddress: Option[Address], correspondenceAddress: Option[Address], prepopAddresses: Map[Int, Address])(implicit request: Request[_], messages: Messages)
 
-@main_template(title = messages("pages.correspondenceAddress.title")) {
+@main_template(title = messages("pages.correspondenceAddress.description")) {
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), chooseAddressForm, dataJourney=Some("CorrespondenceAddress")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.correspondenceAddress.title")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.correspondenceAddress.description")</h1>
 
     @govHelpers.form(action = controllers.userJourney.routes.PAYEContactController.submitPAYECorrespondenceAddress) {
         <div class="form-group">
@@ -23,7 +23,7 @@
                 ).flatten.++(
                     prepopAddresses.map {case (k, v) => s"${PrepopAddress.prefix}$k" -> addressDisplay(v, s"${PrepopAddress.prefix.toLowerCase}$k").toString}.toList
                 ).:+("other" -> messages("pages.correspondenceAddress.other")),
-                '_legend -> messages("pages.correspondenceAddress.legend"),
+                '_legend -> messages("pages.correspondenceAddress.description"),
                 '_legendID -> "chosenAddress",
                 '_helpText -> None,
                 '_labelAfter -> true,

--- a/app/views/pages/payeContact/payeContactDetails.scala.html
+++ b/app/views/pages/payeContact/payeContactDetails.scala.html
@@ -5,8 +5,8 @@
 
 @formContent = {
     <fieldset>
-        <legend class="visuallyhidden">
-            @Messages("pages.payeContact.heading")
+        <legend class="visually-hidden">
+            @Messages("pages.payeContact.description")
         </legend>
         <div class="form-group">
             @payeInput(
@@ -37,19 +37,19 @@
     </fieldset>
 }
 
-@main_template(title = messages("pages.payeContact.title")) {
+@main_template(title = messages("pages.payeContact.description")) {
 
     @payeErrorSummary(
         messages("app.common.errorSummaryLabel"), contactForm, dataJourney=Some("PAYEContactDetails")
     )
 
-    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.payeContact.heading")</h1>
+    <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.payeContact.description")</h1>
 
     @govHelpers.form(action = controllers.userJourney.routes.PAYEContactController.submitPAYEContactDetails()) {
 
         <div class="form-group">
             <fieldset>
-                <legend class="visuallyhidden">
+                <legend class="visually-hidden">
                     @Html(messages("pages.payeContact.p1"))
                 </legend>
                 <div class="form-group">

--- a/app/views/pages/summary.scala.html
+++ b/app/views/pages/summary.scala.html
@@ -4,8 +4,8 @@
 
 @(summaryModel: Summary)(implicit request: Request[_], messages: Messages)
 
-@main_template(title = Messages("pages.summary.title")) {
-    <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.summary.heading")</h1>
+@main_template(title = Messages("pages.summary.description")) {
+    <h1 class="form-title heading-large" id="pageHeading">@Messages("pages.summary.description")</h1>
 
     @for(section <- summaryModel.sections) {
         <h2 class="heading-medium" id="@{section.id}SectionHeading">@Messages(s"pages.summary.${section.id}.sectionHeading")</h2>

--- a/app/views/pages/welcome.scala.html
+++ b/app/views/pages/welcome.scala.html
@@ -3,10 +3,10 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import helpers.templates.linkNewWindow
 
-@main_template(title = Messages("pages.welcome.title")) {
+@main_template(title = Messages("pages.welcome.description")) {
 
         <header class="page-header">
-            <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.welcome.heading")</h1>
+            <h1 class="form-title heading-xlarge" id="pageHeading">@Messages("pages.welcome.description")</h1>
         </header>
 
         <p class="lede spaced-below" id="subHeading">@Messages("pages.welcome.heading1.register")</p>

--- a/app/views/timeout.scala.html
+++ b/app/views/timeout.scala.html
@@ -1,8 +1,8 @@
 @()(implicit request: Request[_], lang: Lang, messages: Messages)
-@main_template(title = Messages("page.timeout.title"), backButton = false){
+@main_template(title = Messages("page.timeout.description"), backButton = false){
 
     <header class="page-header">
-        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.timeout.heading")</h1>
+        <h1 class="form-title heading-xlarge" id="main-heading">@Messages("page.timeout.description")</h1>
     </header>
 
     <p>@Messages("page.timeout.p1")</p>

--- a/conf/messages
+++ b/conf/messages
@@ -33,12 +33,11 @@ pages.common.companiesHouse.hiddenIntro2.label          = sign back into this se
 pages.common.companiesHouse.hiddenIntro2.url            = https://www.gov.uk/limited-company-formation/register-your-company
 pages.common.companiesHouse.hiddenIntro2.2              = to continue your application.
 
-#timeout page
-page.timeout.title = Your session has timed out due to inactivity
-page.timeout.heading = Your session has timed out due to inactivity
-page.timeout.p1 = Your answers have been saved.
-page.timeout.p2 = Sign in to
-page.timeout.url = continue registration
+## timeout page
+page.timeout.description                                = Your session has timed out due to inactivity
+page.timeout.p1                                         = Your answers have been saved.
+page.timeout.p2                                         = Sign in to
+page.timeout.url                                        = continue registration
 
 ## User error messages
 errors.invalid.email                                    = The email address you have provided is invalid
@@ -54,8 +53,7 @@ errors.invalid.sic.invalidChars                         = Enter a business descr
 errors.invalid.name.invalidChars                        = Enter a contact name using valid characters
 
 ## Welcome page
-pages.welcome.title                                     = Register as an employer for PAYE
-pages.welcome.heading                                   = Register as an employer for PAYE
+pages.welcome.description                               = Register as an employer for PAYE
 pages.welcome.heading1.register                         = PAYE is HM Revenue and Customs'' (HMRC) system to collect Income Tax and National Insurance from employment. It stands for '' Pay As You Earn''.
 pages.welcome.heading2.register                         = Use this service if any of the following apply:
 pages.welcome.bullet.pay                                = it pays employees - including company directors - £113 or more a week (this is the same as £490 a month or £5,876 a year)
@@ -72,13 +70,11 @@ pages.welcome.nino                                      = You''ll need the Natio
 pages.welcome.application                               = Your application shouldn''t take more than 10 minutes to complete. You''ll need to allow 2 weeks for HMRC to process it.
 
 ## Company Eligibility
-pages.companyEligibility.title                          = Is the company an offshore employer outside the European Economic Area that doesn''t pay UK National Insurance?
-pages.companyEligibility.heading                        = Is the company an offshore employer outside the European Economic Area that doesn''t pay UK National Insurance?
+pages.companyEligibility.description                    = Is the company an offshore employer outside the European Economic Area that doesn''t pay UK National Insurance?
 pages.companyEligibility.error                          = Tell us if any of the following apply to you
 
 ## Director Eligibility
-pages.directorEligibility.title                         = Does the company pay out any non-cash incentive awards?
-pages.directorEligibility.heading                       = Does the company pay out any non-cash incentive awards?
+pages.directorEligibility.description                   = Does the company pay out any non-cash incentive awards?
 pages.employingStaff.directorEligibilityRulesIntro1     = This could be to anyone, not just your own staff.
 pages.employingStaff.directorEligibilityRulesIntro2     = Non-cash incentive awards include:
 pages.employingStaff.directorEligibility1               = vouchers - including ones that can be exchanged for cash
@@ -88,9 +84,7 @@ pages.employingStaff.directorEligibility4               = holidays the company p
 pages.directorEligibility.error                         = Tell us if the company pays out non-cash incentive awards
 
 ## Completion Capacity page
-pages.completionCapacity.title                          = What is your relationship to the company?
-pages.completionCapacity.heading                        = What is your relationship to the company?
-pages.completionCapacity.legend                         = What is your relationship to the company?
+pages.completionCapacity.description                    = What is your relationship to the company?
 pages.completionCapacity.director                       = Company director
 pages.completionCapacity.secretary                      = Company secretary
 pages.completionCapacity.agent                          = Agent - for example, an accountant
@@ -100,8 +94,7 @@ pages.completionCapacity.error                          = Tell us your relations
 pages.completionCapacity.other.error                    = Enter your relationship to the business using 100 characters or less
 
 ## Trading Name Page
-pages.tradingName.title                                 = Will the company trade under another name?
-pages.tradingName.heading                               = Will the company trade under another name?
+pages.tradingName.description                           = Will the company trade under another name?
 pages.tradingName.lede                                  = Tell us if you''ll trade using a different name to {0}.
 pages.tradingName.tradingNameLabel                      = Enter the trading name
 pages.tradingName.nameRulesSummary                      = What are the rules for trading names?
@@ -118,31 +111,28 @@ pages.tradingName.errorQuestion                         = Enter a trading name
 pages.tradingName.error                                 = Tell us if the company trades under any other name
 
 
-##Confirm RO Address
-pages.confirmRO.title                                   = Confirm the company''s registered office address
-pages.confirmRO.heading                                 = Confirm the company''s registered office address
+## Confirm RO Address
+pages.confirmRO.description                             = Confirm the company''s registered office address
 pages.confirmRO.lede                                    = This is the official address of {0}. It''s where legal notices and company''s post will be sent.
 pages.confirmRO.help.link                               = Not the right address?
 pages.confirmRO.hiddenIntro.value                       = registered office address is
 pages.confirmRO.hiddenIntro.label                       = change it with Companies House.
 
-##PPOB Address
-pages.ppobAddress.title                                 = Where will the company carry out most of its business activities?
-pages.ppobAddress.heading                               = Where will the company carry out most of its business activities?
+## PPOB Address
+pages.ppobAddress.description                           = Where will the company carry out most of its business activities?
 pages.ppobAddress.other                                 = A different address
 pages.ppobAddress.addressChoice.noEntry                 = Tell us where you''ll carry out most of your business activities
 pages.ppobAddress.peopleIntro1                          = This can be your home, a commercial office, a studio or workshop. You or the company don''t need to own the property.
 pages.ppobAddress.peopleIntro2                          = If you work in different locations, use the address where the company keeps its stock or equipment.
 
 ##Correspondence Address
-pages.correspondenceAddress.title                       = Where should we send post about the company''s PAYE?
+pages.correspondenceAddress.description                 = Where should we send post about the company''s PAYE?
 pages.correspondenceAddress.lede                        = We''ll use this address to send post relating to your PAYE scheme.
 pages.correspondenceAddress.other                       = A different address
 pages.correspondenceAddress.addressChoice.noEntry       = Tell us the company''s correspondence address
 
 ## Business Contact Details
-pages.businessContact.title                             = What are the company''s contact details?
-pages.businessContact.heading                           = What are the company''s contact details?
+pages.businessContact.description                       = What are the company''s contact details?
 pages.businessContactDetails.p1                         = Let us know how we can get in touch if we need more information about the company.
 pages.businessContactDetails.p2.indent                  = You need to provide at least one of the following contact details.
 pages.businessContact.email                             = Email address
@@ -151,8 +141,7 @@ pages.businessContact.othercontact                      = Other contact number (
 pages.businessContact.noFieldsCompleted                 = Enter at least one company contact detail
 
 ## PAYE Contact Details
-pages.payeContact.title                                 = Who should we contact about the company''s PAYE?
-pages.payeContact.heading                               = Who should we contact about the company''s PAYE?
+pages.payeContact.description                           = Who should we contact about the company''s PAYE?
 pages.payeContact.p1                                    = Let us know who we can contact if we need more information about the company''s PAYE scheme.
 pages.payeContact.contactName                           = Contact name
 pages.payeContact.email                                 = Email address
@@ -162,9 +151,7 @@ pages.payeContact.noFieldsCompleted                     = You need to provide at
 pages.payeContact.nameMandatory                         = Enter a contact name
 
 ## Employing Staff Page
-pages.employingStaff.title                              = Over the next 2 months will the company pay any staff, including directors?
-pages.employingStaff.heading                            = Over the next 2 months will the company pay any staff, including directors?
-pages.employingStaff.legend                             = Over the next 2 months will the company pay any staff, including directors?
+pages.employingStaff.description                        = Over the next 2 months will the company pay any staff, including directors?
 pages.employingStaff.employingStaffRulesIntro           = This includes:
 pages.employingStaff.employingStaffRules1               = people already employed by the company
 pages.employingStaff.employingStaffRules2               = directors or company secretaries who receive a salary either as a regular wage or lump sum
@@ -172,18 +159,14 @@ pages.employingStaff.error                              = Tell us if over the ne
 
 
 ## Subcontractors Page
-pages.subcontractors.title                              = Will the company use subcontractors in the construction industry?
-pages.subcontractors.heading                            = Will the company use subcontractors in the construction industry?
-pages.subcontractors.legend                             = Will the company use subcontractors in the construction industry?
+pages.subcontractors.description                        = Will the company use subcontractors in the construction industry?
 pages.subcontractors.nameRulesIntro                     = We''ll register the company with the Construction Industry Scheme (CIS) if the company pays subcontractors to do construction work.
 pages.subcontractors.findout1                           = Find out
 pages.subcontractors.findout2                           = what work is covered by the CIS
 pages.subcontractors.error                              = Tell us if the company will use subcontractors in the construction industry
 
 ## Company Pension Page
-pages.companyPension.title                              = Will the company make pension payments to a former employee or their dependants in the next 2 months?
-pages.companyPension.heading                            = Will the company make pension payments to a former employee or their dependants in the next 2 months?
-pages.companyPension.legend                             = Will the company make pension payments to a former employee or their dependants in the next 2 months?
+pages.companyPension.description                        = Will the company make pension payments to a former employee or their dependants in the next 2 months?
 pages.companyPension.setUpPensionIntro                  = This includes payments to:
 pages.companyPension.setUpPension1                      = an employee who has retired
 pages.companyPension.setUpPension2                      = any dependants of an employee who has died
@@ -191,9 +174,7 @@ pages.companyPension.error                              = Tell us if you will ma
 
 
 ## First Payment Page
-pages.firstPayment.title                                = Set the company''s PAYE scheme start date
-pages.firstPayment.heading                              = Set the company''s PAYE scheme start date
-pages.firstPayment.legend                               = Set the company''s PAYE scheme start date
+pages.firstPayment.description                          = Set the company''s PAYE scheme start date
 pages.firstPayment.firstPaymentLabel                    = First Payment
 pages.firstPayment.intro                                = The PAYE scheme will start on the date of the company''s first payment to an employee or subcontractor.
 pages.firstPayment.hint                                 = For example, 12 8 2017
@@ -206,14 +187,11 @@ pages.firstPayment.listElement2                         = within the next 2 mont
 pages.firstPayment.indent                               = The PAYE scheme will be cancelled if the company doesn''t pay anyone within the next 2 months.
 
 ## NATURE OF BUSINESS
-pages.natureOfBusiness.title                            = What does the company do?
-pages.natureOfBusiness.heading                          = What does the company do?
+pages.natureOfBusiness.description                      = What does the company do?
 pages.natureOfBusiness.textArea.label                   = Enter a description of the type of goods or services the company sells.
 
 ## Director Details Page
-pages.directorDetails.title                             = What is the National Insurance number of at least one company director?
-pages.directorDetails.legend                            = What is the National Insurance number of at least one company director?
-pages.directorDetails.heading                           = What is the National Insurance number of at least one company director?
+pages.directorDetails.description                       = What is the National Insurance number of at least one company director?
 pages.directorDetails.errors.noneCompleted              = Enter at least one director''s National Insurance number
 pages.directorDetails.information.indent                = You can find a National Insurance number on a National Insurance card, benefit letter, payslip or P60.
 pages.directorDetails.information.dropdown.header       = Not the right directors?
@@ -224,8 +202,7 @@ pages.directorDetails.hiddenIntro.label                 = change them with Compa
 pages.directorDetails.name-suffix                       = {0}''s National Insurance number
 
 ## Summary Page
-pages.summary.title                                     = Check and confirm your answers
-pages.summary.heading                                   = Check and confirm your answers
+pages.summary.description                               = Check and confirm your answers
 
 pages.summary.employees.sectionHeading                  = Employment information
 pages.summary.employees.question                        = Over the next 2 months will you pay any staff, including yourself?
@@ -305,8 +282,7 @@ pages.summary.information                                = By submitting this ap
 
 
 ## Confirmation Page
-pages.confirmation.title                                = Application complete
-pages.confirmation.heading                              = Application submitted
+pages.confirmation.description                          = Application submitted
 pages.confirmation.reference                            = Your reference number is
 pages.confirmation.heading2                             = What happens next?
 pages.confirmation.p1                                   = If your application is successful we''ll send you:
@@ -315,8 +291,7 @@ pages.confirmation.bullet2                              = an activation PIN for 
 pages.confirmation.p2                                   = You''ll need these to send payroll information to HMRC.
 
 ## Ineligible
-pages.ineligible.title                                  = The company can''t register as an employer online
-pages.ineligible.heading                                = The company can''t register as an employer online
+pages.ineligible.description                            = The company can''t register as an employer online
 pages.ineligible.p1                                     = You should register by phone or post.
 pages.ineligible.p2.1                                   = Contact HMRC
 pages.ineligible.p2.2                                   = - they''ll arrange for someone to call you back to help you register.
@@ -329,11 +304,9 @@ pages.ineligible.l5                                     = company registration n
 pages.ineligible.l6                                     = the names and National Insurance numbers of every company director
 
 ## Error Pages
-errorPages.title                                        = Something went wrong
-errorPages.restart.heading                              = Sorry, we''re having technical issues.
+errorPages.restart.description                          = Sorry, we''re having technical issues.
 errorPages.restart.p1                                   = You can try again by <a href={0}>restarting</a> your PAYE registration.
-errorPages.ineligible.title                             = You don''t need to register as an employer
-errorPages.ineligible.heading                           = You don''t need to register as an employer
+errorPages.ineligible.description                       = You don''t need to register as an employer
 errorPages.ineligible.p1                                = If you''re not going to employ staff or subcontractors in the next 2 months, you don''t need to register as an employer.
 errorPages.ineligible.p2                                = However, you''ll have to register if your plans change and you start paying:
 errorPages.ineligible.l1                                = employees
@@ -341,18 +314,17 @@ errorPages.ineligible.l2                                = subcontractors
 errorPages.ineligible.l3                                = yourself if you''re a director of a company
 
 ## Feedback page
-page.feedback.title                                     = Feedback
-page.feedback.thank-you.title                           = Thank you
-page.feedback.heading                                   = Send your feedback
+page.feedback.description                               = Feedback
+page.feedback.thank-you                                 = Thank you
 
 ## Retry Submission
-errorPages.retrySubmission.title                        = We couldn''t process your application
+errorPages.retrySubmission.description                  = We couldn''t process your application
 errorPages.retrySubmission.p1                           = Sorry, there is a technical problem and we couldn''t process your application. Any details you entered have been saved.
 errorPages.retrySubmission.p2                           = Please resend your application.
 errorPages.retrySubmission.button                       = Resend
 
 ## Failed Submission
-errorPages.failedSubmission.title                        = We couldn''t process your application
+errorPages.failedSubmission.description                  = We couldn''t process your application
 errorPages.failedSubmission.p1                           = Sorry, there is a technical problem and we couldn''t process your application. Any details you entered have been saved.
 errorPages.failedSubmission.p2                           = Fill out the form below so we can help you complete your application.
 errorPages.failedSubmission.header                       = Your details
@@ -363,28 +335,25 @@ errorPages.failedSubmission.q3                           = What were you doing?
 errorPages.failedSubmission.button                       = Send
 
 ## Deskpro Submitedd
-errorPages.deskproSubmitted.title                        = Thank you
-errorPages.deskproSubmitted.heading                      = Thank you
+errorPages.deskproSubmitted.description                  = Thank you
 errorPages.deskproSubmitted.p1                           = Your submission has been received.
 errorPages.deskproSubmitted.p2                           = We''ll be in touch as soon as we can to help you complete your application.
 
 ## Address Lookup Frontend Configuration
+pages.alf.common.lookupPage.title                        = Search for your address
+pages.alf.common.lookupPage.heading                      = Search for your address
 pages.alf.common.navTitle                                = Register your company
 pages.alf.common.phaseBannerHtml                         = This is a new service. Help us improve it - send your <a href="https://www.tax.service.gov.uk/register-for-paye/feedback">feedback</a>.
 pages.alf.common.deskProServiceName                      = SCRS
-pages.alf.common.lookupPage.title                        = Search for your address
-pages.alf.common.lookupPage.heading                      = Search for your address
 pages.alf.common.lookupPage.filterLabel                  = House name or number (optional)
 pages.alf.common.lookupPage.submitLabel                  = Search address
 
 pages.alf.ppob.lookupPage.title                          = Company address
 pages.alf.correspondence.lookupPage.title                = Search for your address
 
-pages.alf.common.selectPage.title                        = Choose an address
-pages.alf.common.selectPage.heading                      = Choose an address
+pages.alf.common.selectPage.description                  = Choose an address
 
-pages.alf.common.editPage.title                          = Enter address
-pages.alf.common.editPage.heading                        = Enter address
+pages.alf.common.editPage.description                    = Enter address
 pages.alf.common.editPage.line1Label                     = Address line 1
 pages.alf.common.editPage.line2Label                     = Address line 2
 pages.alf.common.editPage.line3Label                     = Address line 3

--- a/test/views/pages/DirectorDetailsViewSpec.scala
+++ b/test/views/pages/DirectorDetailsViewSpec.scala
@@ -62,7 +62,7 @@ class DirectorDetailsViewSpec extends PAYERegSpec with I18nSupport {
     lazy val document = Jsoup.parse(view.body)
 
     "have the title for a single director" in {
-      document.getElementById("pageHeading").text shouldBe messagesApi("pages.directorDetails.title")
+      document.getElementById("pageHeading").text shouldBe messagesApi("pages.directorDetails.description")
     }
 
     "display the directors name and prepopped Nino" in {
@@ -80,7 +80,7 @@ class DirectorDetailsViewSpec extends PAYERegSpec with I18nSupport {
     lazy val document = Jsoup.parse(view.body)
 
     "have the title for many directors" in {
-      document.getElementById("pageHeading").text shouldBe messagesApi("pages.directorDetails.title")
+      document.getElementById("pageHeading").text shouldBe messagesApi("pages.directorDetails.description")
     }
 
     "have all directors shown" in {

--- a/test/views/pages/NatureOfBusinessViewSpec.scala
+++ b/test/views/pages/NatureOfBusinessViewSpec.scala
@@ -33,7 +33,7 @@ class NatureOfBusinessViewSpec extends PAYERegSpec with I18nSupport {
     lazy val document = Jsoup.parse(view.body)
 
     "have the correct title" in {
-      document.getElementById("pageHeading").text shouldBe messagesApi("pages.natureOfBusiness.heading")
+      document.getElementById("pageHeading").text shouldBe messagesApi("pages.natureOfBusiness.description")
     }
 
     "have the correct label text" in {

--- a/test/views/pages/companyDetails/ConfirmROAddressViewSpec.scala
+++ b/test/views/pages/companyDetails/ConfirmROAddressViewSpec.scala
@@ -44,7 +44,7 @@ class ConfirmROAddressViewSpec extends PAYERegSpec with I18nSupport {
     lazy val document = Jsoup.parse(view.body)
 
     "have the correct title" in {
-      document.getElementById("pageHeading").text shouldBe messagesApi("pages.confirmRO.title")
+      document.getElementById("pageHeading").text shouldBe messagesApi("pages.confirmRO.description")
     }
 
     "have the correct lede paragraph" in {

--- a/test/views/pages/companyDetails/chooseAddressSpec.scala
+++ b/test/views/pages/companyDetails/chooseAddressSpec.scala
@@ -84,7 +84,7 @@ class chooseAddressSpec extends PAYERegSpec with I18nSupport {
     lazy val document = Jsoup.parse(view.body)
 
     "have the correct title" in {
-      document.getElementById("pageHeading").text shouldBe messagesApi("pages.ppobAddress.heading")
+      document.getElementById("pageHeading").text shouldBe messagesApi("pages.ppobAddress.description")
     }
 
     "have the correct name for radio button roAddress" in {
@@ -163,7 +163,7 @@ class chooseAddressSpec extends PAYERegSpec with I18nSupport {
     lazy val document = Jsoup.parse(view.body)
 
     "have the correct title" in {
-      document.getElementById("pageHeading").text shouldBe messagesApi("pages.correspondenceAddress.title")
+      document.getElementById("pageHeading").text shouldBe messagesApi("pages.correspondenceAddress.description")
     }
 
     "have the correct name for radio button roAddress" in {


### PR DESCRIPTION
Part of the DAC report for PAYE noticed we had some missing and unhelpful legends in our fieldsets, which they failed us on. This PR addrsses that and as part of that work I have refactored messages.

### Refactor messages
Currently we have .title, .heading and .legend in messages to display
the title, heading and legend for all pages. While this makes logical
sense, these 3 text snippets are all the same and I don't think it
makes sense that there's 3 messages in conf/messages, when 1 can be
used to represent all 3. I have refactored and updated these and on
some pages updated broken links to the messages files, fixing other
issues as part of the work to check and update legends that are
failing DAC testing.