### PR TITLE
Updating input type number to type tel to improve accessibility

### DIFF
--- a/app/views/helpers/templates/inlineDateInput.scala.html
+++ b/app/views/helpers/templates/inlineDateInput.scala.html
@@ -20,7 +20,7 @@
     formItem(s"${fieldName}Day"),
     '_label -> Messages("app.common.day"),
     '_labelClass -> "form-group form-group-day",
-    '_type -> "number",
+    '_type -> "tel",
     '_inputClass -> s"input--xxsmall input--no-spinner",
     '_maxlength -> "2"
     )
@@ -29,7 +29,7 @@
     formItem(s"${fieldName}Month"),
     '_label -> Messages("app.common.month"),
     '_labelClass -> "form-group form-group-month",
-    '_type -> "number",
+    '_type -> "tel",
     '_inputClass -> s"input--xxsmall input--no-spinner",
     '_maxlength -> "2"
     )
@@ -38,7 +38,7 @@
     formItem(s"${fieldName}Year"),
     '_label -> Messages("app.common.year"),
     '_labelClass -> "form-group form-group-year",
-    '_type -> "number",
+    '_type -> "tel",
     '_inputClass -> s"input--small input--no-spinner",
     '_maxlength -> "4"
     )


### PR DESCRIPTION
DAC failed us for using type number for date inputs because Dragon
software had issues accessing the inputs. After some looking into
this Chris Moore suggested we use type="tel" instead.