### PR TITLE
Improve print styles for summary page

### DIFF
--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -22,6 +22,7 @@
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/paye.css")">
     <link rel="stylesheet" href="@routes.Assets.at("stylesheets/timeout-dialog.css")">
+    <link rel="stylesheet" media="print" href="@routes.Assets.at("stylesheets/paye-print.css")">
     @pageCSS
 }
 

--- a/public/stylesheets/paye-print.css
+++ b/public/stylesheets/paye-print.css
@@ -1,0 +1,55 @@
+/* Print styles to improve Summary / Check your answers pages */
+
+/* removes padding so the content aligns with the header in print */
+article h1+h2 {
+	margin-bottom: 30px;
+}
+
+.heading-medium {
+	margin: 10px 0 10px;
+}
+
+
+/* Styles for layout using dl */
+
+.govuk-check-your-answers {
+	margin: 0 0 40px; 
+}
+
+.cya-question,
+.cya-answer {
+	display: inline-block;
+	width: 50%;
+	vertical-align: top !important;
+}
+
+.cya-answer {
+	width: 33.33%;
+	padding: 10px 0;
+	margin-bottom: 0;
+}
+
+
+/* template styles */
+#global-header {
+	margin-bottom: 0;
+}
+
+#content {
+	padding: 0;
+}
+
+.cya-change,
+.report-error,
+.button,
+.link-back,
+.phase-banner,
+.header__menu__proposition-links,
+.menu {
+	display: none;
+}
+
+.header__menu__proposition-name {
+	color: #000;
+	font-size: 27px;
+}


### PR DESCRIPTION
This work has been done for CT, at some point when I have collaborated with HMRC this will live in HMRC AF, so we can remove the local styles.

## Before
[PAYE-CYA-before.pdf](https://github.com/hmrc/paye-registration-frontend/files/1829984/PAYE-CYA-before.pdf)

## After
[PAYE-CYA-after.pdf](https://github.com/hmrc/paye-registration-frontend/files/1829985/PAYE-CYA-after.pdf)
