### PR TITLE
[SCRS-11714]: fix redirection when CT registration is in locked status

### DIFF
--- a/app/utils/SessionProfile.scala
+++ b/app/utils/SessionProfile.scala
@@ -69,7 +69,9 @@ trait SessionProfile extends InternalExceptions {
     currentProfile match {
       case CurrentProfile(_, CompanyRegistrationProfile(_, _, Some(a)), _, _, _) if Try(a.toInt).getOrElse(6) >= 6 =>
         Future.successful(Redirect(controllers.userJourney.routes.SignInOutController.postSignIn()))
-      case CurrentProfile(_, compRegProfile, _, _, _) if compRegProfile.status equals "draft" =>
+      case CurrentProfile(_, CompanyRegistrationProfile("locked", _, _) , _, _, _) =>
+        Future.successful(Redirect(controllers.userJourney.routes.SignInOutController.postSignIn()))
+      case CurrentProfile(_, CompanyRegistrationProfile("draft", _, _) , _, _, _) =>
         Future.successful(Redirect("https://www.tax.service.gov.uk/business-registration/select-taxes"))
       case CurrentProfile(_, _, _, true, _) if checkSubmissionStatus =>
         Future.successful(Redirect(controllers.userJourney.routes.DashboardController.dashboard()))

--- a/it/frontend/PAYEContactDetailsMethodISpec.scala
+++ b/it/frontend/PAYEContactDetailsMethodISpec.scala
@@ -726,7 +726,6 @@ class PAYEContactDetailsMethodISpec extends IntegrationSpecBase
       val reqPosts = findAll(postRequestedFor(urlMatching(s"/write/audit")))
       val captorPost = reqPosts.get(0)
       val json = Json.parse(captorPost.getBodyAsString)
-      println("json")
       (json \ "auditSource").as[JsString].value mustBe "paye-registration-frontend"
       (json \ "auditType").as[JsString].value mustBe "correspondenceAddress"
       (json \ "detail" \ "externalUserId").as[JsString].value mustBe "Ext-xxx"
@@ -735,7 +734,6 @@ class PAYEContactDetailsMethodISpec extends IntegrationSpecBase
       (json \ "detail" \ "addressUsed").as[JsString].value mustBe "PrincipalPlaceOfBusiness"
 
       val tags = (json \ "tags").as[JsObject].value
-      println(tags)
       tags("clientIP") mustBe Json.toJson("-")
       tags("path") mustBe Json.toJson("/register-for-paye/where-to-send-post")
       tags("clientPort") mustBe Json.toJson("-")

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -22,7 +22,7 @@ object AppDependencies {
 }
 
 object MainDependencies {
-  private val frontendBootstrapVersion        = "8.20.0"
+  private val frontendBootstrapVersion        = "8.24.0"
   private val authClientVersion               = "2.6.0"
   private val playPartialsVersion             = "6.1.0"
   private val httpCachingVersion              = "7.1.0"

--- a/test/utils/SessionProfileSpec.scala
+++ b/test/utils/SessionProfileSpec.scala
@@ -166,8 +166,14 @@ class SessionProfileSpec extends PayeComponentSpec {
       val res = testSession.currentProfileChecks(cp)(_ => Future.successful(Ok))
       redirectLocation(res) mustBe Some(s"${controllers.userJourney.routes.SignInOutController.postSignIn()}")
     }
+    s"redirect user to ${controllers.userJourney.routes.SignInOutController.postSignIn().url} when CT is locked status" in new Setup {
+      val cp = validProfile(regSubmitted = false).copy(companyTaxRegistration = CompanyRegistrationProfile("locked","bar",None))
+
+      val res = testSession.currentProfileChecks(cp)(_ => Future.successful(Ok))
+      redirectLocation(res) mustBe Some(s"${controllers.userJourney.routes.SignInOutController.postSignIn()}")
+    }
     s"redirect user to otrs" in new Setup {
-      val cp = validProfile(regSubmitted = false).copy(companyTaxRegistration = CompanyRegistrationProfile("draft","bar",Some("3")))
+      val cp = validProfile(regSubmitted = false).copy(companyTaxRegistration = CompanyRegistrationProfile("draft","bar",None))
 
       val res = testSession.currentProfileChecks(cp)(_ => Future.successful(Ok))
       redirectLocation(res) mustBe Some("https://www.tax.service.gov.uk/business-registration/select-taxes")

--- a/test/views/pages/DirectorDetailsViewSpec.scala
+++ b/test/views/pages/DirectorDetailsViewSpec.scala
@@ -29,14 +29,14 @@ class DirectorDetailsViewSpec extends PayeComponentSpec with PayeFakedApp with I
   implicit val request = FakeRequest()
   implicit lazy val messagesApi : MessagesApi = mockMessagesApi
 
-  val d1 = "Henri Lay (id 0)"
-  val d2 = "Chris Walker (id 1)"
-  val d3 = "Tom Stacey (id 2)"
-  val d4 = "Jhansi Tummala (id 3)"
-  val d5 = "Chris Poole (id 4)"
+  val d1 = "Toto Tata (id 0)"
+  val d2 = "Bib Bloup (id 1)"
+  val d3 = "Pill Poll (id 2)"
+  val d4 = "Jag Land (id 3)"
+  val d5 = "Grep Sed (id 4)"
 
   val userNinos = Ninos(List(UserEnteredNino("0", Some("ZY123456A"))))
-  val directorMap = Map("0" -> "Henri Lay (id 0)")
+  val directorMap = Map("0" -> "Toto Tata (id 0)")
 
   val userNinosMany = Ninos(
     List(
@@ -66,7 +66,7 @@ class DirectorDetailsViewSpec extends PayeComponentSpec with PayeFakedApp with I
     }
 
     "display the directors name and prepopped Nino" in {
-      document.getElementsByClass("form-field").get(0).text mustBe "Henri Lay (id 0)'s National Insurance number For example, QQ 12 34 56 C"
+      document.getElementsByClass("form-field").get(0).text mustBe "Toto Tata (id 0)'s National Insurance number For example, QQ 12 34 56 C"
       document.getElementsByAttributeValueContaining("value", "ZY 12 34 56 A").size mustBe 1
     }
 


### PR DESCRIPTION
# [SCRS-11714] - fix the check on CT 'locked' status to redirect to CT post-sign-in

**Bug fix**

Page guard check on current profile, if CT status is locked it redirects to CT post-sign-in

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date
