### PR TITLE
Scrs 11714

### DIFF
--- a/app/connectors/CompanyRegistrationConnector.scala
+++ b/app/connectors/CompanyRegistrationConnector.scala
@@ -18,10 +18,9 @@ package connectors
 
 import common.exceptions
 import common.exceptions.DownstreamExceptions
-import javax.inject.Inject
 import config.WSHttp
+import javax.inject.Inject
 import models.external.CompanyRegistrationProfile
-import play.api.Logger
 import play.api.libs.json._
 import services.MetricsService
 import uk.gov.hmrc.http.{BadRequestException, CoreGet, HeaderCarrier, HttpException}
@@ -62,8 +61,9 @@ trait CompanyRegistrationConnector {
         _ => throw new exceptions.DownstreamExceptions.ConfirmationRefsNotFoundException,
         identity
       )
+      val paidIncorporation = (response \ "confirmationReferences" \ "payment-reference").asOpt[String]
       val ackStatus = (response \ "acknowledgementReferences" \ "status").asOpt[String]
-      CompanyRegistrationProfile(status, txId, ackStatus)
+      CompanyRegistrationProfile(status, txId, ackStatus, paidIncorporation)
     } recover {
       case badRequestErr: BadRequestException =>
         companyRegTimer.stop()

--- a/app/models/external/BusinessRegistration.scala
+++ b/app/models/external/BusinessRegistration.scala
@@ -35,7 +35,8 @@ object BusinessProfile {
 
 case class CompanyRegistrationProfile(status: String,
                                       transactionId: String,
-                                      ackRefStatus: Option[String] = None)
+                                      ackRefStatus: Option[String] = None,
+                                      paidIncorporation: Option[String] = None)
 
 object CompanyRegistrationProfile {
   implicit val formats = Json.format[CompanyRegistrationProfile]

--- a/app/utils/SessionProfile.scala
+++ b/app/utils/SessionProfile.scala
@@ -44,11 +44,13 @@ trait SessionProfile extends InternalExceptions {
               payeRegistrationService.handleIIResponse(cp.companyTaxRegistration.transactionId, res.get) map {
                 case RegistrationDeletion.success => Redirect(controllers.userJourney.routes.SignInOutController.incorporationRejected())
                 case _ =>
-                  Logger.warn(s"Registration txId: ${cp.companyTaxRegistration.transactionId} - regId: ${cp.registrationID} incorporation is rejected but the cleanup failed probably due to the wrong status of the paye registration")
+                  Logger.warn(s"Registration txId: ${cp.companyTaxRegistration.transactionId} - regId: ${cp.registrationID} " +
+                    s"incorporation is rejected but the cleanup failed probably due to the wrong status of the paye registration")
                   Redirect(controllers.userJourney.routes.SignInOutController.postSignIn())
               } recover {
                 case err =>
-                  Logger.error(s"Registration txId: ${cp.companyTaxRegistration.transactionId} - regId: ${cp.registrationID} Incorporation is rejected but handleIIResponse threw an unexpected exception whilst trying to cleanup with message: ${err.getMessage}")
+                  Logger.error(s"Registration txId: ${cp.companyTaxRegistration.transactionId} - regId: ${cp.registrationID} " +
+                    s"Incorporation is rejected but handleIIResponse threw an unexpected exception whilst trying to cleanup with message: ${err.getMessage}")
                   Redirect(controllers.userJourney.routes.SignInOutController.incorporationRejected())
               }
             } else {
@@ -67,17 +69,22 @@ trait SessionProfile extends InternalExceptions {
 
   protected[utils] def currentProfileChecks(currentProfile: CurrentProfile, checkSubmissionStatus: Boolean = true)(f: CurrentProfile => Future[Result]): Future[Result] = {
     currentProfile match {
-      case CurrentProfile(_, CompanyRegistrationProfile(_, _, Some(a)), _, _, _) if Try(a.toInt).getOrElse(6) >= 6 =>
+      case CurrentProfile(_, CompanyRegistrationProfile(_, _, Some(a), _), _, _, _) if Try(a.toInt).getOrElse(6) >= 6 =>
         Future.successful(Redirect(controllers.userJourney.routes.SignInOutController.postSignIn()))
-      case CurrentProfile(_, CompanyRegistrationProfile("locked", _, _) , _, _, _) =>
+      case CurrentProfile(_, CompanyRegistrationProfile("held", _, _, None) , _, _, _) =>
         Future.successful(Redirect(controllers.userJourney.routes.SignInOutController.postSignIn()))
-      case CurrentProfile(_, CompanyRegistrationProfile("draft", _, _) , _, _, _) =>
+      case CurrentProfile(_, CompanyRegistrationProfile("locked", _, _, _) , _, _, _) =>
+        Future.successful(Redirect(controllers.userJourney.routes.SignInOutController.postSignIn()))
+      case CurrentProfile(_, CompanyRegistrationProfile("draft", _, _, hasPaid) , _, _, _) =>
+        if(hasPaid.isDefined){ Logger.warn("[CurrentProfileChecks] CR Document status DRAFT but user HAS PAID for incorporation") }
         Future.successful(Redirect("https://www.tax.service.gov.uk/business-registration/select-taxes"))
       case CurrentProfile(_, _, _, true, _) if checkSubmissionStatus =>
         Future.successful(Redirect(controllers.userJourney.routes.DashboardController.dashboard()))
       case CurrentProfile(_, _, _, _, Some(IncorporationStatus.rejected)) =>
         Future.successful(Redirect(controllers.userJourney.routes.SignInOutController.incorporationRejected()))
-      case cp => f(cp)
+      case cp @ CurrentProfile(_, CompanyRegistrationProfile(_, _, _, hasPaid), _, _, _) =>
+        if(hasPaid.isEmpty){ Logger.warn("[CurrentProfileChecks] CT PROCESSED but user HAS NO PAYMENT REFERENCE for incorporation") }
+        f(cp)
     }
   }
 }

--- a/app/views/error_template.scala.html
+++ b/app/views/error_template.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
 
 @contentHeader = {

--- a/app/views/feedback.scala.html
+++ b/app/views/feedback.scala.html
@@ -1,18 +1,18 @@
 @*
-* Copyright 2016 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
 
 @import uk.gov.hmrc.play.partials.FormPartialRetriever
 

--- a/app/views/feedback_thankyou.scala.html
+++ b/app/views/feedback_thankyou.scala.html
@@ -1,18 +1,18 @@
 @*
-* Copyright 2018 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
 
 @import uk.gov.hmrc.play.partials.CachedStaticHtmlPartialRetriever
 

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(appConfig: config.AppConfig,
   title: String,
   mainClass: Option[String] = None,

--- a/app/views/helpers/mainContentHeader.scala.html
+++ b/app/views/helpers/mainContentHeader.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(backButtonEnabled: Boolean)(implicit messages: Messages)
 
 <div id="global-header-bar"></div>

--- a/app/views/helpers/templates/addressBlockDisplay.scala.html
+++ b/app/views/helpers/templates/addressBlockDisplay.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.Address
 @(address : Address, blockId : String)
 

--- a/app/views/helpers/templates/addressDisplay.scala.html
+++ b/app/views/helpers/templates/addressDisplay.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.Address
 @(address : Address, blockId : String)
 

--- a/app/views/helpers/templates/formHiddenYesNoRadio.scala.html
+++ b/app/views/helpers/templates/formHiddenYesNoRadio.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(form: Form[_], fieldName: String, questionText: String, content:Html, hiddenTitle: Option[String] = None, helpText:Option[String] = None)(implicit lang: play.api.i18n.Lang, messages: Messages)
 
 <div class="form-group" data-hidden='hidden'>

--- a/app/views/helpers/templates/hiddenDetails.scala.html
+++ b/app/views/helpers/templates/hiddenDetails.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(summaryId: String, summaryText: String, hiddenContent: Html)(implicit messages: Messages)
 
 <details role="group">

--- a/app/views/helpers/templates/inlineDateInput.scala.html
+++ b/app/views/helpers/templates/inlineDateInput.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(formItem:Form[_],
     fieldName: String,
     hintText: Option[Html],

--- a/app/views/helpers/templates/inputRadioGroupHidden.scala.html
+++ b/app/views/helpers/templates/inputRadioGroupHidden.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(field: Field,
   radioOptions: Seq[(String, String)],
   hiddenElem: Seq[(String, Html)],

--- a/app/views/helpers/templates/linkNewWindow.scala.html
+++ b/app/views/helpers/templates/linkNewWindow.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(href: String, text: String, dataJourney: String, htmlId: Option[String] = None)(implicit messages: Messages)
 
 <a href="@{href}" @{htmlId.map(id => s"id=$id")} data-external-link="externalLink|@{dataJourney}|@{href}" target="_blank">@text @Messages("app.common.linkHelperText")</a>

--- a/app/views/helpers/templates/oneOfManyErrorWrapper.scala.html
+++ b/app/views/helpers/templates/oneOfManyErrorWrapper.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(form: Form[_], html: Html)(implicit messages: Messages)
 
 @errs = @{form.errors.filter(_.key.contains("noFieldsCompleted"))}

--- a/app/views/helpers/templates/payeErrorSummary.scala.html
+++ b/app/views/helpers/templates/payeErrorSummary.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(heading: String, form: Form[_], classes: Seq[String] = Seq.empty, dataJourney: Option[String] = None)(implicit messages: Messages)
 
 <div class="error-summary@if(form.hasErrors) { error-summary--show} @classes.mkString(" ")"

--- a/app/views/helpers/templates/payeInput.scala.html
+++ b/app/views/helpers/templates/payeInput.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2018 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit messages: Messages)
 
 @import play.api.i18n._

--- a/app/views/helpers/templates/payeInputRadioGroup.scala.html
+++ b/app/views/helpers/templates/payeInputRadioGroup.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(field: Field, radioOptions: Seq[(String, String)], args: (Symbol, Any)*)(implicit lang: play.api.i18n.Lang, messages: Messages)
 
 @import views.html.helper._

--- a/app/views/helpers/templates/payeTextArea.scala.html
+++ b/app/views/helpers/templates/payeTextArea.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2018 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit messages: Messages)
 
 @import play.api.i18n._

--- a/app/views/helpers/templates/simpleNoErrorInput.scala.html
+++ b/app/views/helpers/templates/simpleNoErrorInput.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit lang: play.api.i18n.Lang, messages: Messages)
 
 @import views.html.helper._

--- a/app/views/helpers/templates/summaryRow.scala.html
+++ b/app/views/helpers/templates/summaryRow.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.view.SummaryRow
 
 @(row: SummaryRow)(implicit messages: Messages)

--- a/app/views/main_template.scala.html
+++ b/app/views/main_template.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(title: String,
   backButton: Boolean = true,
   sidebarLinks: Option[Html] = None,

--- a/app/views/pages/annual/FirstPaymentInNextTaxYear.scala.html
+++ b/app/views/pages/annual/FirstPaymentInNextTaxYear.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @import utils.SystemDate

--- a/app/views/pages/companyDetails/businessContactDetails.scala.html
+++ b/app/views/pages/companyDetails/businessContactDetails.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payeInput}
 @import models.DigitalContactDetails
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/companyDetails/confirmROAddress.scala.html
+++ b/app/views/pages/companyDetails/confirmROAddress.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{addressBlockDisplay, hiddenDetails}
 @import models.Address
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/companyDetails/ppobAddress.scala.html
+++ b/app/views/pages/companyDetails/ppobAddress.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{addressDisplay, payeInputRadioGroup, payeErrorSummary}
 @import models.Address
 @import models.view.{ChosenAddress, PrepopAddress}

--- a/app/views/pages/companyDetails/tradingName.scala.html
+++ b/app/views/pages/companyDetails/tradingName.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{formHiddenYesNoRadio, hiddenDetails, payeErrorSummary, payeInput}
 @import models.view.TradingName
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/completionCapacity.scala.html
+++ b/app/views/pages/completionCapacity.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.view.CompletionCapacity
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import views.html.helpers.templates.{inputRadioGroupHidden, payeErrorSummary, payeInput}

--- a/app/views/pages/confirmation.scala.html
+++ b/app/views/pages/confirmation.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import views.html.helpers.templates.hiddenDetails
 @import helpers.templates.linkNewWindow
 

--- a/app/views/pages/directorDetails.scala.html
+++ b/app/views/pages/directorDetails.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{hiddenDetails, oneOfManyErrorWrapper, payeErrorSummary, payeInput}
 @import models.view.Ninos
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/eligibility/companyEligibility.scala.html
+++ b/app/views/pages/eligibility/companyEligibility.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.CompanyEligibility
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/eligibility/directorEligibility.scala.html
+++ b/app/views/pages/eligibility/directorEligibility.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.DirectorEligibility
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/eligibility/ineligible.scala.html
+++ b/app/views/pages/eligibility/ineligible.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @()(implicit request: Request[_], messages: Messages)
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/employmentDetails/applicationDelayed.scala.html
+++ b/app/views/pages/employmentDetails/applicationDelayed.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
 @()(implicit request: Request[_], messages: Messages)

--- a/app/views/pages/employmentDetails/companyPension.scala.html
+++ b/app/views/pages/employmentDetails/companyPension.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.CompanyPension
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/employmentDetails/constructionIndustry.scala.html
+++ b/app/views/pages/employmentDetails/constructionIndustry.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import helpers.templates.linkNewWindow

--- a/app/views/pages/employmentDetails/employingStaff.scala.html
+++ b/app/views/pages/employmentDetails/employingStaff.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.EmployingStaff
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/employmentDetails/employsSubcontractors.scala.html
+++ b/app/views/pages/employmentDetails/employsSubcontractors.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import helpers.templates.linkNewWindow

--- a/app/views/pages/employmentDetails/firstPayment.scala.html
+++ b/app/views/pages/employmentDetails/firstPayment.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{hiddenDetails, inlineDateInput, payeErrorSummary}
 @import models.view.FirstPayment
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/employmentDetails/paidEmployees.scala.html
+++ b/app/views/pages/employmentDetails/paidEmployees.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{hiddenDetails, inlineDateInput, payeInputRadioGroup, payeErrorSummary, formHiddenYesNoRadio}
 @import models.view.EmployingAnyone
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/employmentDetails/paysPension.scala.html
+++ b/app/views/pages/employmentDetails/paysPension.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 

--- a/app/views/pages/employmentDetails/subcontractors.scala.html
+++ b/app/views/pages/employmentDetails/subcontractors.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary}
 @import models.view.Subcontractors
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/employmentDetails/willBePaying.scala.html
+++ b/app/views/pages/employmentDetails/willBePaying.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import java.time.LocalDate
 @import helpers.templates.{payeInputRadioGroup, payeErrorSummary, formHiddenYesNoRadio}
 @import models.view.WillBePaying

--- a/app/views/pages/error/ineligible.scala.html
+++ b/app/views/pages/error/ineligible.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @()(implicit request: Request[_], messages: Messages)
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/error/newIneligible.scala.html
+++ b/app/views/pages/error/newIneligible.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(threshold : Int)(implicit request: Request[_], messages: Messages)
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/error/restart.scala.html
+++ b/app/views/pages/error/restart.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @()(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("errorPages.restart.description")) {

--- a/app/views/pages/error/submissionFailed.scala.html
+++ b/app/views/pages/error/submissionFailed.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @()(implicit request: Request[_], messages: Messages)
 
 @main_template(title = Messages("errorPages.failedSubmission.description")) {

--- a/app/views/pages/error/submissionTimeout.scala.html
+++ b/app/views/pages/error/submissionTimeout.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @()(implicit request: Request[_], messages: Messages)
 
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/natureOfBusiness.scala.html
+++ b/app/views/pages/natureOfBusiness.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.view.NatureOfBusiness
 @import helpers.templates.{payeTextArea, payeErrorSummary}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/payeContact/correspondenceAddress.scala.html
+++ b/app/views/pages/payeContact/correspondenceAddress.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.Address
 @import models.view.{ChosenAddress, PrepopAddress}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/payeContact/payeContactDetails.scala.html
+++ b/app/views/pages/payeContact/payeContactDetails.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{oneOfManyErrorWrapper, payeErrorSummary, payeInput}
 @import models.view.PAYEContactDetails
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/summary.scala.html
+++ b/app/views/pages/summary.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.summaryRow
 @import models.view.Summary
 @import uk.gov.hmrc.play.views.html.helpers.form

--- a/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/coHoCompanyDetailsSetup.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeErrorSummary, payeInput}
 @import models.test.CoHoCompanyDetailsFormModel
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
+++ b/app/views/pages/test/payeRegCompanyDetailsSetup.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{payeErrorSummary, payeInput}
 @import models.api.{CompanyDetails => CompanyDetailsAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/test/payeRegEmploymentInfoSetup.scala.html
+++ b/app/views/pages/test/payeRegEmploymentInfoSetup.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{inlineDateInput, payeErrorSummary, payeInput}
 @import models.api.EmploymentV2
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}

--- a/app/views/pages/test/payeRegPAYEContactSetup.scala.html
+++ b/app/views/pages/test/payeRegPAYEContactSetup.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import models.api.{PAYEContact => PAYEContactAPI}
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import helpers.templates.{inlineDateInput, payeErrorSummary, payeInput}

--- a/app/views/pages/test/payeRegistrationSetup.scala.html
+++ b/app/views/pages/test/payeRegistrationSetup.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import helpers.templates.{inlineDateInput, payeErrorSummary, payeInput}
 @import models.api.{PAYERegistration => PAYERegistrationAPI}
 @import pages.test.testHelpers.manualPrePopulatedInput

--- a/app/views/pages/test/testHelpers/manualPrePopulatedInput.scala.html
+++ b/app/views/pages/test/testHelpers/manualPrePopulatedInput.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(field: play.api.data.Field, args: (Symbol,Any)*)(implicit messages: Messages)
 
 @import play.api.i18n._

--- a/app/views/pages/test/updateCCPage.scala.html
+++ b/app/views/pages/test/updateCCPage.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 @import helpers.templates.payeInput
 

--- a/app/views/pages/welcome.scala.html
+++ b/app/views/pages/welcome.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @(thresholdMap: Map[String, Int])(implicit request: Request[_], messages: Messages)
 
 @import uk.gov.hmrc.play.views.html.helpers.form

--- a/app/views/timeout.scala.html
+++ b/app/views/timeout.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @()(implicit request: Request[_], lang: Lang, messages: Messages)
 @main_template(title = Messages("page.timeout.description"), backButton = false){
 

--- a/it/payeregistrationapi/CompanyRegistrationConnectorISpec.scala
+++ b/it/payeregistrationapi/CompanyRegistrationConnectorISpec.scala
@@ -61,9 +61,20 @@ class CompanyRegistrationConnectorISpec extends IntegrationSpecBase {
           |{
           |    "status" : "testStatus",
           |    "confirmationReferences" : {
-          |      "transaction-id" : "$transId"
+          |      "transaction-id" : "$transId",
+          |      "payment-reference" : "paidcashmoney"
           |    }
           |}
+        """.stripMargin).as[JsObject]
+    def responseBodyUnpaid(transId: String) =
+      Json.parse(
+        s"""
+           |{
+           |    "status" : "testStatus",
+           |    "confirmationReferences" : {
+           |      "transaction-id" : "$transId"
+           |    }
+           |}
         """.stripMargin).as[JsObject]
 
     "get a status and a transaction id" when {
@@ -94,6 +105,7 @@ class CompanyRegistrationConnectorISpec extends IntegrationSpecBase {
         val result = await(getResponse)
         result.status mustBe "testStatus"
         result.transactionId mustBe "testTransactionID-001"
+        result.paidIncorporation mustBe Some("paidcashmoney")
       }
 
       "the feature flag points at the Company Registration" in {
@@ -125,13 +137,14 @@ class CompanyRegistrationConnectorISpec extends IntegrationSpecBase {
           .willReturn(
             aResponse()
               .withStatus(200)
-              .withBody(Json.toJson(responseBody("testTransactionID-001")).toString())
+              .withBody(Json.toJson(responseBodyUnpaid("testTransactionID-001")).toString())
           )
         )
 
         val result = await(getResponse)
         result.status mustBe "testStatus"
         result.transactionId mustBe "testTransactionID-001"
+        result.paidIncorporation mustBe None
       }
     }
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,8 +17,8 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "1.4.0")
-addSbtPlugin("uk.gov.hmrc"        %  "sbt-git-versioning"     % "0.9.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-auto-build"         % "1.8.0")
+addSbtPlugin("uk.gov.hmrc"        %  "sbt-git-versioning"     % "0.10.0")
 addSbtPlugin("uk.gov.hmrc"        %  "sbt-distributables"     % "1.0.0")
 addSbtPlugin("com.typesafe.play"  %  "sbt-plugin"             % "2.5.12")
 addSbtPlugin("org.scalastyle"     %% "scalastyle-sbt-plugin"  % "0.8.0")

--- a/test/controllers/userJourney/PayeStartControllerSpec.scala
+++ b/test/controllers/userJourney/PayeStartControllerSpec.scala
@@ -134,7 +134,7 @@ class PayeStartControllerSpec extends PayeComponentSpec with PayeFakedApp {
 
     "redirect to the start page for an authorised user with a registration ID and CoHo Company Details, with PAYE Footprint correctly asserted" in new Setup {
       when(mockCurrentProfileService.fetchAndStoreCurrentProfile(ArgumentMatchers.any()))
-        .thenReturn(Future.successful(validCurrentProfile("held")))
+        .thenReturn(Future.successful(validCurrentProfile("submitted")))
 
       when(mockPayeRegService.assertRegistrationFootprint(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
         .thenReturn(Future(DownstreamOutcome.Success))
@@ -148,7 +148,7 @@ class PayeStartControllerSpec extends PayeComponentSpec with PayeFakedApp {
 
     "redirect to the start page for an authorised user with valid details, with PAYE Footprint correctly asserted, with CT accepted" in new Setup {
       when(mockCurrentProfileService.fetchAndStoreCurrentProfile(ArgumentMatchers.any()))
-        .thenReturn(Future.successful(validCurrentProfile("held", Some("04"))))
+        .thenReturn(Future.successful(validCurrentProfile("acknowledged", Some("04"))))
 
       when(mockPayeRegService.assertRegistrationFootprint(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
         .thenReturn(Future(DownstreamOutcome.Success))
@@ -157,6 +157,38 @@ class PayeStartControllerSpec extends PayeComponentSpec with PayeFakedApp {
         result =>
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some("/register-for-paye/register-as-employer")
+      }
+    }
+
+    "redirect to Start Page for an authorised user with valid details, with CT submitted and with incorporation paid" in new Setup {
+      when(mockCurrentProfileService.fetchAndStoreCurrentProfile(ArgumentMatchers.any()))
+        .thenReturn(Future.successful(
+            CurrentProfile("testRegId", CompanyRegistrationProfile("held", "txId", None, Some("paid")), "en", false, None)
+          ))
+
+      when(mockPayeRegService.assertRegistrationFootprint(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
+        .thenReturn(Future(DownstreamOutcome.Success))
+
+      AuthHelpers.showAuthorisedOrg(controller().startPaye, fakeRequest) {
+        result =>
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some("/register-for-paye/register-as-employer")
+      }
+    }
+
+    "redirect to Company Registration for an authorised user with valid details, with CT submitted but with incorporation unpaid" in new Setup {
+      when(mockCurrentProfileService.fetchAndStoreCurrentProfile(ArgumentMatchers.any()))
+        .thenReturn(Future.successful(
+            CurrentProfile("testRegId", CompanyRegistrationProfile("held", "txId", None, None), "en", false, None)
+          ))
+
+      when(mockPayeRegService.assertRegistrationFootprint(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
+        .thenReturn(Future(DownstreamOutcome.Success))
+
+      AuthHelpers.showAuthorisedOrg(controller().startPaye, fakeRequest) {
+        result =>
+          status(result) mustBe SEE_OTHER
+          redirectLocation(result) mustBe Some("/register-for-paye/post-sign-in")
       }
     }
 
@@ -197,7 +229,7 @@ class PayeStartControllerSpec extends PayeComponentSpec with PayeFakedApp {
 
     "redirect the user to post sign in if their CT is rejected" in new Setup {
       when(mockCurrentProfileService.fetchAndStoreCurrentProfile(ArgumentMatchers.any()))
-        .thenReturn(Future.successful(validCurrentProfile("submitted", Some("06"))))
+        .thenReturn(Future.successful(validCurrentProfile("acknowledged", Some("06"))))
 
       AuthHelpers.showAuthorisedOrg(controller().startPaye, fakeRequest) {
         result =>

--- a/test/helpers/fixtures/CurrentProfileFixtures.scala
+++ b/test/helpers/fixtures/CurrentProfileFixtures.scala
@@ -23,7 +23,9 @@ trait CurrentProfileFixtures {
     registrationID = "testRegId",
     companyTaxRegistration = CompanyRegistrationProfile(
       status = "testStatus",
-      transactionId = "testTxId"
+      transactionId = "testTxId",
+      ackRefStatus = None,
+      paidIncorporation = None
     ),
     language = "EN",
     payeRegistrationSubmitted = false,

--- a/test/helpers/mocks/KeystoreMock.scala
+++ b/test/helpers/mocks/KeystoreMock.scala
@@ -23,8 +23,7 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.mockito.stubbing.OngoingStubbing
 import play.api.libs.json.Format
-import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
@@ -55,7 +54,7 @@ trait KeystoreMock {
     when(mockKeystoreConnector.fetchAndGet[CurrentProfile](ArgumentMatchers.any())(ArgumentMatchers.any[HeaderCarrier](), ArgumentMatchers.any[Format[CurrentProfile]]()))
         .thenReturn(Future.successful(Some(CurrentProfile(
           regID,
-          CompanyRegistrationProfile("held", "txId"),
+          CompanyRegistrationProfile("held", "txId", None, None),
           "ENG",
           payeRegistrationSubmitted = false,
           incorpStatus = None


### PR DESCRIPTION
# SCRS-11714 - Added held scenarios to PAYE profile checks, logging for unexpected but none-blocking scenarios

**New feature**

Added held status scenarios. Due to the joint flow with CH, the only way to understand the true state of a CR Document is to use a combination of the document status and payment references. See ticket for business scenarios.

## Checklist

* [x] I've included appropriate tests with any code I've added
* [x] I've executed the acceptance test pack locally to ensure there are no regressions
* [x] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [x] I've run a dependency check to ensure all dependencies are up to date
