### PR TITLE
DL-9460 updated error code response when business profile not found

### DIFF
--- a/app/connectors/BusinessRegistrationConnector.scala
+++ b/app/connectors/BusinessRegistrationConnector.scala
@@ -16,6 +16,7 @@
 
 package connectors
 
+import common.exceptions.DownstreamExceptions.CurrentProfileNotFoundException
 import config.AppConfig
 import connectors.httpParsers.BusinessRegistrationHttpParsers
 import models.Address
@@ -38,7 +39,8 @@ class BusinessRegistrationConnector @Inject()(val metricsService: MetricsService
     infoLog("[retrieveCurrentProfile] attempting to retrieveCurrentProfile")
     withTimer {
       withRecovery()("retrieveCurrentProfile") {
-        http.GET[BusinessProfile](s"$businessRegUrl/business-registration/business-tax-registration")(businessProfileHttpReads, hc, ec)
+        http.GET[Option[BusinessProfile]](s"$businessRegUrl/business-registration/business-tax-registration")(businessProfileHttpReads, hc, ec)
+          .map(_.getOrElse(throw new CurrentProfileNotFoundException))
       }
     }
   }

--- a/app/connectors/httpParsers/BusinessRegistrationHttpParsers.scala
+++ b/app/connectors/httpParsers/BusinessRegistrationHttpParsers.scala
@@ -30,8 +30,8 @@ trait BusinessRegistrationHttpParsers extends BaseHttpReads { _: BaseConnector =
   override def unexpectedStatusException(url: String, status: Int, regId: Option[String], txId: Option[String]): Exception =
     new DownstreamExceptions.BusinessRegistrationException(s"Calling url: '$url' returned unexpected status: '$status'${logContext(regId, txId)}")
 
-  def businessProfileHttpReads()(implicit request: Request[_]): HttpReads[BusinessProfile] =
-    httpReads("businessProfileHttpReads")
+  def businessProfileHttpReads()(implicit request: Request[_]): HttpReads[Option[BusinessProfile]] =
+    optionHttpReads("businessProfileHttpReads")
 
   def retrieveCompletionCapacityHttpReads()(implicit request: Request[_]): HttpReads[Option[String]] = {
     implicit val reads = (__ \ "completionCapacity").read[String]

--- a/app/connectors/test/TestBusinessRegConnector.scala
+++ b/app/connectors/test/TestBusinessRegConnector.scala
@@ -39,7 +39,7 @@ trait TestBusinessRegConnector extends BaseConnector with BusinessRegistrationHt
 
   def createBusinessProfileEntry(implicit hc: HeaderCarrier, request: Request[_]): Future[BusinessProfile] =
     http.POST[BusinessRegistrationRequest, BusinessProfile](s"$businessRegUrl/business-registration/business-tax-registration", BusinessRegistrationRequest("ENG"))(
-      BusinessRegistrationRequest.formats, businessProfileHttpReads, hc, ec
+      BusinessRegistrationRequest.formats, businessProfileHttpReads.map(_.get), hc, ec
     )
 
   def updateCompletionCapacity(regId: String, completionCapacity: String)(implicit hc: HeaderCarrier): Future[String] = {

--- a/app/controllers/userJourney/PayeStartController.scala
+++ b/app/controllers/userJourney/PayeStartController.scala
@@ -16,7 +16,7 @@
 
 package controllers.userJourney
 
-import common.exceptions.DownstreamExceptions.ConfirmationRefsNotFoundException
+import common.exceptions.DownstreamExceptions.{ConfirmationRefsNotFoundException, CurrentProfileNotFoundException}
 import config.AppConfig
 import connectors._
 import controllers.{AuthRedirectUrls, PayeBaseController}
@@ -101,6 +101,7 @@ class PayeStartController @Inject()(val currentProfileService: CurrentProfileSer
     } recover {
       case _: NotFoundException => Redirect("https://www.tax.service.gov.uk/business-registration/select-taxes")
       case _: ConfirmationRefsNotFoundException => Redirect("https://www.tax.service.gov.uk/business-registration/select-taxes")
+      case _: CurrentProfileNotFoundException => NotFound(restart())
       case _ =>
         warnLog(s"[checkAndStoreCurrentProfile] failed to checkAndStoreCurrentProfile")
         InternalServerError(restart())

--- a/app/services/CurrentProfileService.scala
+++ b/app/services/CurrentProfileService.scala
@@ -25,7 +25,7 @@ import play.api.libs.json.Json
 import play.api.mvc.{AnyContent, Request}
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.{Logging, RegistrationAllowlist}
-
+import common.exceptions
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/test/connectors/httpParsers/BusinessRegistrationHttpParsersSpec.scala
+++ b/test/connectors/httpParsers/BusinessRegistrationHttpParsersSpec.scala
@@ -50,17 +50,16 @@ class BusinessRegistrationHttpParsersSpec extends PayeComponentSpec with LogCapt
         "response is OK and JSON is valid" must {
 
           "return the Business Profile" in {
-
-            BusinessRegistrationHttpParsers.businessProfileHttpReads.read("", "", HttpResponse(OK, json = businessProfileJson, Map())) mustBe businessProfile
+            BusinessRegistrationHttpParsers.businessProfileHttpReads.read("", "", HttpResponse(OK, json = businessProfileJson, Map())) mustBe Some(businessProfile)
           }
         }
 
         "response is OK and JSON is malformed" must {
 
-          "return a JsResultException and log an error message" in {
+          "return a None and log an error message" in {
 
             withCaptureOfLoggingFrom(BusinessRegistrationHttpParsers.logger) { logs =>
-              intercept[JsResultException](BusinessRegistrationHttpParsers.businessProfileHttpReads.read("", "", HttpResponse(OK, json = Json.obj(), Map())))
+              BusinessRegistrationHttpParsers.businessProfileHttpReads.read("", "", HttpResponse(OK, json = Json.obj(), Map())) mustBe None
               logs.containsMsg(Level.ERROR, "[businessProfileHttpReads] JSON returned could not be parsed to models.external.BusinessProfile model")
             }
           }


### PR DESCRIPTION
!!! :guardsman: PLEASE UPDATE THE TEXT BELOW AND REMOVE THIS LINE :guardsman: !!!

# DL-9460 - Returns NotFound when business registration profile cannot be found instead of 500

**Bug fix*

- Added an exception thrown for when BusinessProfile is missing
- Updated json reads to be optional to return the exception.
- Updated tests

## Checklist

* [ ] I've included appropriate tests with any code I've added
* [ ] I've executed the acceptance test pack locally to ensure there are no regressions
* [ ] I've added my code using logical, atomic commits, squashing as appropriate - including the Jira issue number in the commit message
* [ ] I've run a dependency check to ensure all dependencies are up to date
